### PR TITLE
Port legacy/mutate.py to Python 3.10+ on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Virtual environment
+.venv/
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Extracted from legacy/wordsEn.zip at runtime, not source
+legacy/wordsEn.txt
+legacy/ReadMe.txt
+
+# Experiment output (see issue #17 for the results directory design).
+# The committed legacy/mutated_*.py files are historical artifacts and ARE tracked.
+results/

--- a/legacy/mutate.py
+++ b/legacy/mutate.py
@@ -1,28 +1,28 @@
 """ mutate.py - a mutation algorithm. """
 
-from __future__ import print_function
-
 import argparse
+import importlib.util
 import os
 import random
 import string
 import subprocess
+import sys
 import time
 import zipfile
-import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-class Creature(object):
+class Creature:
     """ This is a creature that can duplicate itself with errors. """
     def __init__(self, path_to_creature):
         assert os.path.sep not in path_to_creature
         self.path_to_creature = path_to_creature
-        self.test_path = 'test_%s' % self.path_to_creature
-        self.mutant_path = 'mutated_%s' % self.path_to_creature
+        self.test_path = f'test_{self.path_to_creature}'
+        self.mutant_path = f'mutated_{self.path_to_creature}'
 
-        creature_file = open(self.path_to_creature)
-        self.creature_content = creature_file.read()
-        creature_file.close()
+        with open(self.path_to_creature, encoding='utf-8') as creature_file:
+            self.creature_content = creature_file.read()
 
     @staticmethod
     def _weighted_choice(choices):
@@ -38,6 +38,9 @@ class Creature(object):
             if upto + weight >= rand_num:
                 return choice
             upto += weight
+        # Floating point rounding can leave rand_num fractionally above the
+        # accumulated total, which previously fell off the end and returned None.
+        return choices[-1][0]
 
     @staticmethod
     def _flawed_copy(source, mutation_weights=None, use_keywords=True):
@@ -81,7 +84,7 @@ class Creature(object):
                 else:
                     source = source[:mutation_location] + mutation + source[mutation_location:]
             else:
-                raise 'Invalid defect: %s' % defect
+                raise ValueError(f'Invalid defect: {defect}')
         return source
 
     def save_mutant(self, creature_content):
@@ -89,10 +92,12 @@ class Creature(object):
         :param creature_content: Text of file to be saved.
         :return: None
         """
-        mutant_path_handle = open(self.mutant_path, 'w')
-        mutant_path_handle.write(creature_content)
-        mutant_path_handle.close()
-        pyc_file = '__pycache__\\%s.cpython-35.pyc' % os.path.splitext(self.mutant_path)[0]
+        with open(self.mutant_path, 'w', encoding='utf-8') as mutant_path_handle:
+            mutant_path_handle.write(creature_content)
+        # Stale bytecode would otherwise be reused, so the mutant that runs would
+        # not be the mutant just written. The original hardcoded a Windows path
+        # for Python 3.5, which silently did nothing on any other platform.
+        pyc_file = importlib.util.cache_from_source(self.mutant_path)
         if os.path.exists(pyc_file):
             os.unlink(pyc_file)
 
@@ -117,14 +122,14 @@ class Creature(object):
         self.save_mutant(self.creature_content)
 
         for i in range(mutations):
-            print('Iteration: %d' % i)
+            print(f'Iteration: {i}')
             mutated_content = self._flawed_copy(self.creature_content, use_keywords=use_keywords)
             print('===== new mutant =====')
             print(mutated_content)
             print('===== new =====')
             self.save_mutant(mutated_content)
 
-            if subprocess.call(['python', cmd]) == 0:
+            if subprocess.call([sys.executable, cmd]) == 0:
                 successful_mutations += 1
                 self.creature_content = mutated_content
                 print('===== succeeded - new creature =====')
@@ -144,33 +149,37 @@ class Creature(object):
 
         self.save_mutant(self.creature_content)
 
-        print('Successful mutations: %d' % successful_mutations)
-        print('Failed mutations: %d' % failed_mutations)
+        print(f'Successful mutations: {successful_mutations}')
+        print(f'Failed mutations: {failed_mutations}')
 
 
-class Dictionary(object):
+class Dictionary:  # pylint: disable=too-few-public-methods
     """ This is a simple dictionary. """
     def __init__(self):
         """ Set up the dictionary.
             :return: None
         """
-        # Make sure we have our spelling list extracted
-        txt_name = 'wordsEN.txt'
+        # Make sure we have our spelling list extracted. Note the capitalisation:
+        # the archive contains 'wordsEn.txt', and the original code looked for
+        # 'wordsEN.txt', which only worked because Windows filenames are
+        # case-insensitive. On Linux it extracted the zip and then failed to find
+        # what it had just extracted, on every single run.
+        txt_name = os.path.join(HERE, 'wordsEn.txt')
         if not os.path.exists(txt_name):
-            zip_name = 'wordsEn.zip'
+            zip_name = os.path.join(HERE, 'wordsEn.zip')
             if os.path.exists(zip_name):
                 if zipfile.is_zipfile(zip_name):
                     with zipfile.ZipFile(zip_name) as zip_file:
-                        zip_file.extractall()
+                        zip_file.extractall(HERE)
                 else:
-                    print('It appears that %s is not a valid zip file.' % zip_name)
-                    raise Exception('Dictionary zip file invalid.')
+                    print(f'It appears that {zip_name} is not a valid zip file.')
+                    raise ValueError('Dictionary zip file invalid.')
             else:
-                print('For spell checking, we need %s from'
-                      'http://www-01.sil.org/linguistics/wordlists/english/wordlist/wordsEn.zip'
-                      'in the current directory.  Did not find this file.' % zip_name)
-                raise Exception('Dictionary zip file missing.')
-        with open(txt_name) as word_file:
+                print(f'For spell checking, we need {zip_name} from '
+                      'http://www-01.sil.org/linguistics/wordlists/english/wordlist/'
+                      'wordsEn.zip.  Did not find this file.')
+                raise FileNotFoundError('Dictionary zip file missing.')
+        with open(txt_name, encoding='utf-8') as word_file:
             self.all_words = [x.strip() for x in word_file]
 
     def spelled_correctly(self, sentence):
@@ -190,7 +199,7 @@ def main(arguments):
     major = 0
     minor = 0
     micro = 2
-    print('mutate %d.%d.%d' % (major, minor, micro))
+    print(f'mutate {major}.{minor}.{micro}')
     parser = argparse.ArgumentParser()
     parser.add_argument("creature",
                         help='Path to the creature to mutate.  Mutated creature will be saved as'
@@ -203,9 +212,10 @@ def main(arguments):
                         action="store_false")
     args = parser.parse_args(arguments)
 
-    print('args: %s' % args)
+    print(f'args: {args}')
     random.seed(args.seed)
-    print('git: %s' % subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8'))
+    git_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
+    print(f'git: {git_sha}')
     if subprocess.call(['git', 'diff-index', '--quiet', 'HEAD', '--']) != 0:
         print('git detects uncommitted changes on top of the above id.')
         print('diff:')

--- a/legacy/requirements.txt
+++ b/legacy/requirements.txt
@@ -1,0 +1,5 @@
+# pylint is used as a *selector* in two experiments (hello_world_tested and
+# english), so its version is part of the experimental setup, not just tooling.
+# A newer pylint enforces different rules and will therefore produce different
+# results. Pinned for reproducibility; record the version with any run.
+pylint==4.0.6

--- a/legacy/test_english.py
+++ b/legacy/test_english.py
@@ -1,5 +1,6 @@
 import unittest
 import subprocess
+import sys
 
 import mutated_english
 import mutate
@@ -8,7 +9,7 @@ import mutate
 class TestEnglish(unittest.TestCase):
     def test_return(self):
         self.assertTrue(mutate.Dictionary().spelled_correctly(mutated_english.QUOTE))
-        self.assertEqual(0, subprocess.call(['pylint', 'mutated_english.py']))
+        self.assertEqual(0, subprocess.call([sys.executable, '-m', 'pylint', 'mutated_english.py']))
 
 
 if __name__ == '__main__':

--- a/legacy/test_hello_world_tested.py
+++ b/legacy/test_hello_world_tested.py
@@ -1,5 +1,6 @@
 import unittest
 import subprocess
+import sys
 
 import mutated_hello_world_tested
 
@@ -7,7 +8,7 @@ import mutated_hello_world_tested
 class TestHelloWorld(unittest.TestCase):
     def test_return(self):
         self.assertEqual('Hello World!', mutated_hello_world_tested.hello_world())
-        self.assertEqual(0, subprocess.call(['pylint', 'mutated_hello_world_tested.py']))
+        self.assertEqual(0, subprocess.call([sys.executable, '-m', 'pylint', 'mutated_hello_world_tested.py']))
 
 
 if __name__ == '__main__':

--- a/legacy/test_mutate.py
+++ b/legacy/test_mutate.py
@@ -1,5 +1,7 @@
-import unittest
+import importlib.util
 import subprocess
+import sys
+import unittest
 
 import mutate
 
@@ -50,8 +52,10 @@ class TestMutate(unittest.TestCase):
         self.assertTrue(dict.spelled_correctly('world'))
         self.assertFalse(dict.spelled_correctly('rieuerugh'))
 
+    @unittest.skipIf(importlib.util.find_spec('pylint') is None,
+                     'pylint not installed; see requirements.txt')
     def test_pylint(self):
-        self.assertEqual(0, subprocess.call(['pylint', 'mutate.py']))
+        self.assertEqual(0, subprocess.call([sys.executable, '-m', 'pylint', 'mutate.py']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #15. Part of #14, phase 1.

The tool did not run at all on a modern Linux Python. It died on the first mutation.

## Bugs found, roughly by severity

**`python` is not on PATH.** `subprocess.call(['python', cmd])` assumed a bare `python`. Ubuntu ships only `python3`, so every run died immediately with `FileNotFoundError`. Now uses `sys.executable`.

**Case-sensitive filename bug.** The dictionary looked for `wordsEN.txt`; the archive contains `wordsEn.txt`. This only ever worked because Windows filenames are case-insensitive. On Linux it extracted the zip and then failed to find the file it had just extracted, every single time. Both spell-check-based experiments were dead on arrival.

**Bytecode invalidation never happened.** `save_mutant()` built `'__pycache__\<name>.cpython-35.pyc'`, a Windows path hardcoded to Python 3.5, and a silent no-op on every other platform. Stale bytecode could be executed instead of the mutant just written, which would silently corrupt results. Now uses `importlib.util.cache_from_source`.

**`raise 'Invalid defect: %s'`** raises a string, which is a `TypeError` on Python 3.

**`_weighted_choice` could return `None`** when floating point rounding left `rand_num` fractionally above the accumulated total.

**Dictionary paths were cwd-relative**, so it only worked from one directory. Now anchored to the module location.

## Also

- The three pylint selectors now invoke it as `sys.executable -m pylint` so it resolves inside a venv.
- The self-lint test skips cleanly when pylint is absent.
- `mutate.py` is at a clean 10.00/10 under pylint 4.0.6 (f-strings, explicit encodings, specific exception types, no `object` base).
- `requirements.txt` pins pylint **exactly**. pylint acts as a *selector* in two experiments, so its version is part of the experimental setup rather than tooling, and a different pylint selects differently. This matters for reproducing the 2016 results and is worth calling out in the writeup.

## Verification

```
$ ../.venv/bin/python -m unittest test_mutate
Ran 4 tests in 1.897s
OK
```

Determinism, seed 7, three consecutive runs:
```
4f964c7613cf
4f964c7613cf
4f964c7613cf
```

Experiments run to completion: `hello_world_untested`, `beak`, `body_plans`, `hello_world_tested`.

Committed `legacy/mutated_*.py` historical artifacts are untouched; a `.gitignore` keeps venv, bytecode, and zip-extracted files out.

## Note for #17

Running an experiment currently overwrites the committed `mutated_*.py` artifact in place, and requires running from inside `legacy/`. Both are addressed by the runner in #17.