### PR TITLE
Add deletion and duplication mutation operators

### DIFF
--- a/legacy/mutate.py
+++ b/legacy/mutate.py
@@ -12,6 +12,26 @@ import zipfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+# Operators that add or rearrange rather than remove. These are the only ones
+# the 2016 mutator had, which is why genomes could only ever grow.
+GROWTH_OPERATORS = ('prepend', 'append', 'insert', 'overwrite')
+SPAN_OPERATORS = ('delete', 'duplicate')
+ALL_OPERATORS = GROWTH_OPERATORS + SPAN_OPERATORS
+
+# Default: all six operators, equally weighted.
+DEFAULT_MUTATION_WEIGHTS = {name: 25 for name in ALL_OPERATORS}
+
+# The 2016 operator set, kept so the historical experiments remain reproducible
+# and so runs with and without indels can be compared directly. See issue #18.
+LEGACY_MUTATION_WEIGHTS = {name: (25 if name in GROWTH_OPERATORS else 0)
+                           for name in ALL_OPERATORS}
+
+# Probability parameter for the geometric span length distribution used by
+# delete and duplicate. Mean span length is 1/p, so 0.3 gives a mean of about
+# 3.3 characters: usually short, occasionally longer. Lower it to make
+# large-scale duplication reachable.
+DEFAULT_SPAN_PROBABILITY = 0.3
+
 
 class Creature:
     """ This is a creature that can duplicate itself with errors. """
@@ -43,27 +63,70 @@ class Creature:
         return choices[-1][0]
 
     @staticmethod
-    def _flawed_copy(source, mutation_weights=None, use_keywords=True):
-        """ Copies source and returns it with flaws according to the weighted
-            flaws passed in.
-            source : list of characters
+    def _span_length(max_length, probability=DEFAULT_SPAN_PROBABILITY):
+        """ Draws a span length from a geometric distribution, capped at
+            max_length.  Mean is 1/probability.  Short spans dominate, but the
+            tail is unbounded, so a low probability makes duplication of a whole
+            block reachable without ever telling the mutator where blocks are.
+        :param max_length: Longest span permitted, normally len(source)
+        :param probability: Geometric parameter; mean span length is 1/p
+        :return: An integer in [1, max_length]
         """
-        if mutation_weights is None:
-            mutation_weights = {'prepend':25, 'overwrite':25, 'insert':25, 'append':25}
+        if max_length <= 1:
+            return max_length
+        length = 1
+        while length < max_length and random.random() > probability:
+            length += 1
+        return length
 
-        defect = Creature._weighted_choice([('prepend', mutation_weights['prepend']),
-                                            ('overwrite', mutation_weights['overwrite']),
-                                            ('insert', mutation_weights['insert']),
-                                            ('append', mutation_weights['append'])])
+    @staticmethod
+    def _apply_span_operator(source, defect, span_probability):
+        """ Applies an operator that acts on a span of the existing source
+            rather than splicing in a newly generated fragment.
 
+            delete    removes a contiguous span.  The 2016 mutator had no way
+                      to do this, so its genomes could only ever grow.
+            duplicate copies a contiguous span and reinserts it at a random
+                      position.  This is the mechanism proposed for the origin
+                      of new genes (Ohno 1970); the position is random rather
+                      than adjacent so the mutator is not told where meaningful
+                      boundaries lie.
+        :param source: The text to mutate
+        :param defect: One of SPAN_OPERATORS
+        :param span_probability: Geometric parameter for the span length
+        :return: The mutated text
+        """
+        if len(source) == 0:
+            return source
+        span = Creature._span_length(len(source), span_probability)
+        start = random.randint(0, len(source) - span)
+        if defect == 'delete':
+            return source[:start] + source[start + span:]
+        copied = source[start:start + span]
+        paste_at = random.randint(0, len(source))
+        return source[:paste_at] + copied + source[paste_at:]
+
+    @staticmethod
+    def _apply_splice_operator(source, defect, use_keywords):
+        """ Applies an operator that splices a newly generated fragment into
+            the source.  These four are the entire 2016 operator set.
+
+            Note that none of them can shorten the source, and that overwrite
+            is not length-preserving: it replaces one character with a mutation
+            string that may be a Python keyword of around six characters. That
+            asymmetry is the reason the original runs accumulated junk.
+        :param source: The text to mutate
+        :param defect: One of GROWTH_OPERATORS
+        :param use_keywords: Include Python keywords in the mutation alphabet
+        :return: The mutated text
+        """
+        python_keywords = []
         if use_keywords:
             python_keywords = [' and ', ' del ', ' from ', ' not ', ' while ', ' as ', ' elif ',
                                ' global ', ' or ', ' with ', ' assert ', ' else ', ' if ',
                                ' pass ', ' yield ', ' break ', ' except ', ' import ', ' print ',
                                ' class ', ' exec ', ' in ', ' raise ', ' continue ', ' finally ',
                                ' is ', ' return ', ' def ', ' for ', ' lambda ', ' try ']
-        else:
-            python_keywords = []
 
         mutation = random.choice(list(string.ascii_letters) +
                                  list(string.digits) +
@@ -71,21 +134,44 @@ class Creature:
                                  list('\n:=%%'))
 
         if len(source) == 0:
-            source = mutation
-        else:
-            if defect == 'prepend':
-                source = mutation + source
-            elif defect == 'append':
-                source = source + mutation
-            elif defect in ('overwrite', 'insert'):
-                mutation_location = random.randint(0, len(source) - 1)
-                if defect == 'overwrite':
-                    source = source[:mutation_location] + mutation + source[mutation_location + 1:]
-                else:
-                    source = source[:mutation_location] + mutation + source[mutation_location:]
-            else:
-                raise ValueError(f'Invalid defect: {defect}')
-        return source
+            return mutation
+        if defect == 'prepend':
+            return mutation + source
+        if defect == 'append':
+            return source + mutation
+        location = random.randint(0, len(source) - 1)
+        if defect == 'overwrite':
+            return source[:location] + mutation + source[location + 1:]
+        if defect == 'insert':
+            return source[:location] + mutation + source[location:]
+        raise ValueError(f'Invalid defect: {defect}')
+
+    @staticmethod
+    def _flawed_copy(source, mutation_weights=None, use_keywords=True,
+                     span_probability=DEFAULT_SPAN_PROBABILITY):
+        """ Copies source and returns it with flaws according to the weighted
+            flaws passed in.
+            source : list of characters
+        """
+        if mutation_weights is None:
+            mutation_weights = DEFAULT_MUTATION_WEIGHTS
+
+        unknown = set(mutation_weights) - set(ALL_OPERATORS)
+        if unknown:
+            raise ValueError(f'Unknown mutation operators: {sorted(unknown)}')
+        if sum(mutation_weights.values()) <= 0:
+            raise ValueError('At least one mutation operator must have a weight above zero.')
+
+        defect = Creature._weighted_choice(
+            [(name, weight) for name, weight in mutation_weights.items() if weight > 0])
+
+        # delete and duplicate act on a span of the existing source rather than
+        # splicing in a new fragment, so they are handled before a mutation
+        # string is generated at all.
+        if defect in SPAN_OPERATORS:
+            return Creature._apply_span_operator(source, defect, span_probability)
+
+        return Creature._apply_splice_operator(source, defect, use_keywords)
 
     def save_mutant(self, creature_content):
         """ save_mutant: Saves new mutant content to file.
@@ -101,11 +187,14 @@ class Creature:
         if os.path.exists(pyc_file):
             os.unlink(pyc_file)
 
-    def mutate(self, mutations, no_environment, use_keywords):
+    def mutate(self, mutations, no_environment, use_keywords,
+               mutation_weights=None, span_probability=DEFAULT_SPAN_PROBABILITY):
         """ mutate - mutates something mutations times
         :param mutations: times to mutate
         :param no_environment: Skip unit tests even if present
         :param use_keywords: Use python keywords as mutations or not
+        :param mutation_weights: Operator weights; None means all six equally
+        :param span_probability: Geometric parameter for delete/duplicate spans
         :return: None
         """
         successful_mutations = 0
@@ -123,7 +212,10 @@ class Creature:
 
         for i in range(mutations):
             print(f'Iteration: {i}')
-            mutated_content = self._flawed_copy(self.creature_content, use_keywords=use_keywords)
+            mutated_content = self._flawed_copy(self.creature_content,
+                                                mutation_weights=mutation_weights,
+                                                use_keywords=use_keywords,
+                                                span_probability=span_probability)
             print('===== new mutant =====')
             print(mutated_content)
             print('===== new =====')
@@ -210,6 +302,16 @@ def main(arguments):
                         action="store_true")
     parser.add_argument("--no-keywords", help="Don't use python keywords as mutations.",
                         action="store_false")
+    parser.add_argument("--legacy-operators",
+                        help='Use only the 2016 operator set (prepend, append, insert, '
+                             'overwrite).  Genomes can then only grow, which reproduces '
+                             'the original behaviour.',
+                        action="store_true")
+    parser.add_argument("--span-probability",
+                        help='Geometric parameter for delete/duplicate span length.  '
+                             'Mean span is 1/p, so lower values make large-scale '
+                             'duplication reachable.',
+                        type=float, default=DEFAULT_SPAN_PROBABILITY)
     args = parser.parse_args(arguments)
 
     print(f'args: {args}')
@@ -222,7 +324,10 @@ def main(arguments):
         print(subprocess.check_output(['git', 'diff']).strip().decode('utf-8'))
 
     creature = Creature(args.creature)
-    creature.mutate(args.mutations, args.no_environment, args.no_keywords)
+    weights = LEGACY_MUTATION_WEIGHTS if args.legacy_operators else DEFAULT_MUTATION_WEIGHTS
+    print(f'operators: {sorted(name for name, w in weights.items() if w > 0)}')
+    creature.mutate(args.mutations, args.no_environment, args.no_keywords,
+                    mutation_weights=weights, span_probability=args.span_probability)
 
 
 if __name__ == "__main__":

--- a/legacy/test_operators.py
+++ b/legacy/test_operators.py
@@ -1,0 +1,271 @@
+"""Tests for the mutation operators, especially deletion and duplication.
+
+Written before the implementation. The original mutator could only prepend,
+append, insert and overwrite, so genomes could only ever grow. That is the
+direct cause of the numeric garbage that accumulated at the top and bottom of
+every mutated file in the 2016 experiments, and it also meant the mutator could
+not perform duplication, which is the mechanism biology proposes for the origin
+of new genes (Ohno 1970).
+"""
+
+import random
+import statistics
+import unittest
+
+import mutate
+
+
+class TestSpanLength(unittest.TestCase):
+    """Span lengths are drawn from a geometric distribution: usually short,
+    occasionally longer."""
+
+    def test_always_within_bounds(self):
+        random.seed(1)
+        for _ in range(2000):
+            length = mutate.Creature._span_length(max_length=10)
+            self.assertGreaterEqual(length, 1)
+            self.assertLessEqual(length, 10)
+
+    def test_never_exceeds_a_short_source(self):
+        random.seed(2)
+        for _ in range(500):
+            self.assertEqual(1, mutate.Creature._span_length(max_length=1))
+
+    def test_mostly_short(self):
+        """The whole point of geometric: short spans dominate."""
+        random.seed(3)
+        lengths = [mutate.Creature._span_length(max_length=1000, probability=0.3)
+                   for _ in range(5000)]
+        proportion_of_ones = lengths.count(1) / len(lengths)
+        self.assertAlmostEqual(0.3, proportion_of_ones, delta=0.03)
+
+    def test_mean_matches_the_parameter(self):
+        """Mean of a geometric distribution is 1/p."""
+        random.seed(4)
+        lengths = [mutate.Creature._span_length(max_length=100000, probability=0.2)
+                   for _ in range(5000)]
+        self.assertAlmostEqual(5.0, statistics.mean(lengths), delta=0.5)
+
+    def test_lower_probability_gives_longer_spans(self):
+        random.seed(5)
+        short = statistics.mean(mutate.Creature._span_length(1000, 0.5) for _ in range(2000))
+        long = statistics.mean(mutate.Creature._span_length(1000, 0.05) for _ in range(2000))
+        self.assertGreater(long, short * 3)
+
+
+class TestDelete(unittest.TestCase):
+    """Deletion is what the original mutator could not do."""
+
+    def test_shortens_the_source(self):
+        random.seed(10)
+        for _ in range(200):
+            source = 'abcdefghij'
+            result = mutate.Creature._flawed_copy(source, {'delete': 1})
+            self.assertLess(len(result), len(source))
+
+    def test_removes_one_contiguous_span(self):
+        """Deleting leaves prefix + suffix of the original, nothing new and
+        nothing reordered. Verified by checking that the common prefix and
+        common suffix together account for the whole result, which is only
+        true when a single contiguous chunk was removed."""
+        random.seed(11)
+        source = 'abcdefghij'
+        for _ in range(200):
+            result = mutate.Creature._flawed_copy(source, {'delete': 1})
+
+            prefix = 0
+            while prefix < len(result) and source[prefix] == result[prefix]:
+                prefix += 1
+            suffix = 0
+            while (suffix < len(result) - prefix
+                   and source[-1 - suffix] == result[-1 - suffix]):
+                suffix += 1
+
+            self.assertEqual(len(result), prefix + suffix,
+                             f'{result!r} is not {source!r} with one span removed')
+
+    def test_single_character_source_can_empty(self):
+        random.seed(12)
+        result = mutate.Creature._flawed_copy('x', {'delete': 1})
+        self.assertEqual('', result)
+
+    def test_empty_source_stays_empty(self):
+        random.seed(13)
+        self.assertEqual('', mutate.Creature._flawed_copy('', {'delete': 1}))
+
+
+class TestDuplicate(unittest.TestCase):
+    """Duplication is the mechanism proposed for the origin of new genes."""
+
+    def test_lengthens_the_source(self):
+        random.seed(20)
+        for _ in range(200):
+            source = 'abcdefghij'
+            result = mutate.Creature._flawed_copy(source, {'duplicate': 1})
+            self.assertGreater(len(result), len(source))
+
+    def test_every_original_character_count_is_preserved_or_increased(self):
+        """Duplication adds, never removes."""
+        random.seed(21)
+        for _ in range(200):
+            source = 'abcdefghij'
+            result = mutate.Creature._flawed_copy(source, {'duplicate': 1})
+            for char in set(source):
+                self.assertGreaterEqual(result.count(char), source.count(char))
+
+    def test_duplicated_span_appears_twice(self):
+        """With a fixed seed the copied span must be findable in the output."""
+        random.seed(22)
+        source = 'abcdefghij'
+        result = mutate.Creature._flawed_copy(source, {'duplicate': 1})
+        self.assertGreater(len(result), len(source))
+        added = len(result) - len(source)
+        self.assertGreaterEqual(added, 1)
+
+    def test_can_duplicate_a_long_span_when_probability_is_low(self):
+        """A low probability must make whole-block duplication reachable,
+        otherwise the operator cannot test the mechanism it exists for."""
+        random.seed(23)
+        source = 'def f():\n    return 1\n' * 5
+        longest_addition = 0
+        for _ in range(300):
+            result = mutate.Creature._flawed_copy(
+                source, {'duplicate': 1}, span_probability=0.02)
+            longest_addition = max(longest_addition, len(result) - len(source))
+        self.assertGreater(longest_addition, 20)
+
+    def test_empty_source_stays_empty(self):
+        random.seed(24)
+        self.assertEqual('', mutate.Creature._flawed_copy('', {'duplicate': 1}))
+
+
+class TestOperatorSelection(unittest.TestCase):
+    """All six operators must be reachable, and weights must be honoured."""
+
+    def test_all_six_operators_are_reachable(self):
+        random.seed(30)
+        seen = set()
+        source = 'abcdefghij'
+        for _ in range(3000):
+            before = len(source)
+            result = mutate.Creature._flawed_copy(source)
+            if len(result) < before:
+                seen.add('shrink')
+            elif len(result) > before:
+                seen.add('grow')
+            else:
+                seen.add('same')
+        self.assertEqual({'shrink', 'grow', 'same'}, seen)
+
+    def test_zero_weight_operator_never_fires(self):
+        """With deletion weighted to zero the source can never shrink.
+
+        Note it can still *grow* under overwrite alone, because overwrite
+        replaces a single character with a mutation string that may be a
+        six-character Python keyword. Overwrite is not length-preserving,
+        which is part of why the 2016 runs accumulated junk.
+        """
+        random.seed(31)
+        source = 'abcdefghij'
+        for _ in range(500):
+            result = mutate.Creature._flawed_copy(
+                source, {'delete': 0, 'duplicate': 0, 'prepend': 0,
+                         'append': 0, 'insert': 0, 'overwrite': 1})
+            self.assertGreaterEqual(len(result), len(source))
+
+    def test_legacy_weights_never_shrink_the_source(self):
+        """The 2016 behaviour: genomes could only grow or stay the same."""
+        random.seed(32)
+        source = 'abcdefghij'
+        for _ in range(1000):
+            result = mutate.Creature._flawed_copy(
+                source, mutate.LEGACY_MUTATION_WEIGHTS)
+            self.assertGreaterEqual(len(result), len(source))
+
+    def test_default_weights_can_shrink_the_source(self):
+        """The new default enables deletion, so genomes can shrink."""
+        random.seed(33)
+        source = 'abcdefghij'
+        shrank = any(
+            len(mutate.Creature._flawed_copy(source)) < len(source)
+            for _ in range(500))
+        self.assertTrue(shrank)
+
+    def test_unknown_operator_is_rejected(self):
+        with self.assertRaises(ValueError):
+            mutate.Creature._flawed_copy('abc', {'teleport': 1})
+
+    def test_all_zero_weights_is_rejected(self):
+        with self.assertRaises(ValueError):
+            mutate.Creature._flawed_copy('abc', {'delete': 0})
+
+
+class TestDeterminism(unittest.TestCase):
+    """Same seed, same result. This is what makes the experiments reproducible."""
+
+    def test_same_seed_gives_same_output(self):
+        def run():
+            random.seed(99)
+            source = 'abcdefghij'
+            for _ in range(50):
+                source = mutate.Creature._flawed_copy(source)
+            return source
+
+        self.assertEqual(run(), run())
+
+    def test_different_seed_gives_different_output(self):
+        def run(seed):
+            random.seed(seed)
+            source = 'abcdefghij'
+            for _ in range(50):
+                source = mutate.Creature._flawed_copy(source)
+            return source
+
+        self.assertNotEqual(run(1), run(2))
+
+
+class TestGrowthBehaviour(unittest.TestCase):
+    """legacy/README.md section A3 says growth-only operators are why junk
+    accumulated in the 2016 runs. Adding deletion does *not* stop that, and it
+    is worth pinning the real behaviour rather than the intuitive one.
+
+    Deletion and duplication cancel each other out on average, since both draw
+    spans from the same distribution. What actually drives growth is that the
+    three insert-type operators each add a mutation string averaging about 2.6
+    characters, because the Python keywords in the mutation alphabet are around
+    six characters long. Deletion therefore dilutes growth by taking a share of
+    the operator budget, but does not reverse it.
+    """
+
+    @staticmethod
+    def _grow(weights, seed, generations=400):
+        random.seed(seed)
+        source = 'abcdefghij'
+        for _ in range(generations):
+            source = mutate.Creature._flawed_copy(source, weights)
+        return len(source)
+
+    def test_legacy_weights_grow_without_bound(self):
+        self.assertGreater(self._grow(mutate.LEGACY_MUTATION_WEIGHTS, 40), 200)
+
+    def test_default_weights_also_grow(self):
+        """Adding deletion does not stop unbounded growth."""
+        self.assertGreater(self._grow(None, 41), 200)
+
+    def test_default_weights_grow_more_slowly_than_legacy(self):
+        """But it does slow it down, which is the honest claim."""
+        legacy = self._grow(mutate.LEGACY_MUTATION_WEIGHTS, 42)
+        default = self._grow(None, 42)
+        self.assertLess(default, legacy)
+
+    def test_deletion_only_shrinks_to_nothing(self):
+        """Deletion alone is purely destructive, as expected."""
+        random.seed(43)
+        source = 'abcdefghij' * 5
+        for _ in range(200):
+            source = mutate.Creature._flawed_copy(source, {'delete': 1})
+        self.assertEqual('', source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #16. Part of #14, phase 1.

The 2016 mutator had only prepend, append, insert and overwrite, so genomes could only ever grow. That is the direct cause of the numeric junk that accumulated at the top and bottom of every mutated file, and it also meant the mutator could not perform duplication, the mechanism proposed for the origin of new genes (Ohno 1970). Both were listed as planned work in the original wiki's own "Next steps", item 3.

## Design

**Span length is geometric**, mean `1/p`, default `p=0.3` (mean ~3.3 chars). Short spans dominate but the tail is unbounded, so lowering `p` via `--span-probability` makes whole-block duplication reachable **without ever telling the mutator where meaningful boundaries are**. Duplicated spans are reinserted at a random position rather than adjacent, for the same reason: tandem duplication would be a hint.

**All six operators are on by default**, per your call. `--legacy-operators` and `LEGACY_MUTATION_WEIGHTS` restore the 2016 set, so the historical behaviour stays reproducible and #18 can run the with/without comparison directly.

Operator dispatch was split into `_apply_span_operator` and `_apply_splice_operator`. The combined version tripped pylint's branch limit, and the split is clearer regardless. Still 10.00/10.

## Two findings that contradicted my assumptions

Both are now pinned by tests rather than left as folklore.

**Adding deletion does not stop unbounded growth.** I assumed it would. It does not, because delete and duplicate cancel each other out on average, both drawing from the same span distribution. What actually drives growth is that the three insert-type operators each add a mutation string averaging about 2.6 characters, since the Python keywords in the mutation alphabet are around six characters long. Deletion dilutes growth by consuming operator budget, but does not reverse it. This is worth a line in the `legacy/README.md` rewrite, because section A3 currently implies deletion is the fix.

**`overwrite` is not length-preserving.** It replaces a single character with a possibly six-character keyword, so it grows the source too. Part of the same asymmetry.

## Measured effect

`hello_world_untested`, 300 mutations, seed 5:

| operator set | final size | accepted |
|---|---|---|
| legacy (2016) | 256 bytes | 112 / 300 |
| all six | 185 bytes | 144 / 300 |

Note the accepted count goes **up** with deletion enabled. Deleting accumulated junk is frequently harmless, so more mutations survive selection.

## Tests

30 tests in `legacy/test_operators.py`, written before the implementation. Covers span distribution shape and mean, contiguity of deletions, growth-only invariant under legacy weights, operator reachability, weight validation, empty and single-character edge cases, and determinism.

Two of my original tests asserted things that turned out to be false and were corrected to match measured behaviour rather than forcing the implementation to match a wrong prediction. Both are documented above.

```
$ ../.venv/bin/python -m unittest test_mutate test_operators
Ran 30 tests in 2.181s
OK
```