### PR TITLE
Rewrite legacy claims against 60 reproducible runs

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,17 +1,23 @@
 # Legacy: Initial Findings (2016-2017)
 
-> **Status: ARCHIVED AND SUPERSEDED.**
+> **Status: the original claims are corrected; the experiments now run.**
 >
-> This directory preserves the first version of the `mutate` project and its published
-> writeup, originally hosted on the GitHub wiki. It is kept for historical continuity
-> and because deleting superseded work is worse practice than correcting it.
+> This directory holds the first version of the `mutate` project and its published
+> writeup, originally hosted on the GitHub wiki.
 >
-> **The corrections in Section A below were published by the author, unprompted, before
-> any external critique.** Several of them materially weaken conclusions stated in the
-> original text, which is reproduced unchanged in Section B.
+> **Section A corrects the original claims.** These were published by the author,
+> unprompted, before any external critique, and several of them materially weaken
+> conclusions stated in the original text. Section C reproduces that original text
+> unchanged.
 >
-> **No result in this directory should be cited as evidence.** The current work is
-> governed by [`../PREREGISTRATION.md`](../PREREGISTRATION.md).
+> **Section B reports what actually happens when the experiments are rerun today**,
+> across five seeds at 1000 generations each, reproducible from a seed and a command.
+> Where the fresh runs bear on a correction, Section A links to them.
+>
+> **What these experiments show is about software, not biology.** Which parts of a
+> codebase survive random change is determined by what the tests cover and by how
+> tightly the syntax couples things together. The original writeup drew conclusions
+> about evolution that the experiments do not support. See A7.
 
 ---
 
@@ -42,10 +48,29 @@ beaks *better* rather than merely *acceptable*.
 This matters because the beak experiment was the project's only claimed demonstration of
 constructive change. That claim is withdrawn.
 
-**Additionally:** the committed artifact does not reproduce the claimed result.
+**The committed artifact does not reproduce the claimed result.**
 `artifacts-2016/mutated_beak.py` is byte-identical to `beak.py` and returns 9, not 3.
-The diff is empty. The 9→3 outcome described in the writeup is not recoverable from
+The diff is empty. The 9 to 3 outcome described in the writeup is not recoverable from
 anything in this repository.
+
+**Rerunning it settles the question.** Across five seeds at 1000 generations each, the
+`9` was never changed to any other digit, not once. Every accepted mutation was
+whitespace or a layout change:
+
+```
+-def get_beak_length():
+-    return 9
++def get_beak_length():  return   9
+```
+
+Two things follow. There is no selective pressure toward a shorter beak, because the
+test accepts every value at or below 9 equally. And a single digit inside a 35 byte
+file is such a small target that random mutation rarely lands on it at all, so even
+neutral drift to a different digit is uncommon. The claim "Adaptation works" is
+withdrawn, and the withdrawal is now backed by a rerunnable experiment rather than by
+reading the test.
+
+Reproduce with: `python legacy/run.py beak --seed 1 --generations 1000`
 
 ### A2. No experiment here used positive selection
 
@@ -81,6 +106,21 @@ that cannot perform the operation proposed to produce new functions, is circular
 "Next steps" section (item 3) of the original text. The criticism is of the conclusions
 drawn before they were implemented, not of the author's awareness of the gap.
 
+**Correction to this correction.** Both operators are now implemented, and adding
+deletion does **not** stop the junk from accumulating. An earlier version of this
+section implied it would. It does not, for two reasons found by measurement:
+
+- Deletion and duplication cancel each other out on average, since both draw span
+  lengths from the same distribution.
+- Growth is actually driven by the three insert-type operators, each of which splices
+  in a mutation string averaging about 2.6 characters, because the Python keywords in
+  the mutation alphabet are around six characters long. `overwrite` is not
+  length-preserving either: it replaces one character with a possibly six-character
+  keyword.
+
+Deletion dilutes growth by consuming part of the operator budget, but does not reverse
+it. Section B reports the measured difference between the two operator sets.
+
 ### A4. The abiogenesis experiment had no binding filter
 
 `abiogenesis.py` is an empty file. The selector runs it and checks for a zero exit code.
@@ -110,7 +150,25 @@ available in [`diffs/`](artifacts-2016/diffs/). They are reproducible from this 
 images were not. This is why evidence now lives in version control rather than in
 external image hosting.
 
-### A6. Scope of the original conclusion
+### A6. Two experiments can never be reproduced as originally run
+
+`hello_world_tested` and `english` use pylint as a **selector**, not as tooling. What
+survives in those runs is whatever pylint of that era happened to accept, so the pylint
+version is part of the experimental setup.
+
+The original runs did not record which pylint they used, and pylint has changed
+substantially since 2016. It now enforces rules that did not exist then, including
+f-string preferences, explicit file encodings, and exception specificity. A mutation
+that survived selection in 2016 may be rejected today purely because the selector
+became stricter.
+
+The 2016 numbers for those two experiments are therefore **permanently
+unreproducible**. Fresh runs reported in Section B are new measurements under a
+recorded pylint version, not confirmations of the old ones, and they should not be read
+as agreeing or disagreeing with the original figures. Every run now records
+`pylint_version` in its manifest so this cannot recur.
+
+### A7. Scope of the original conclusion
 
 The concluding claim, that mutation and selection "were not shown to have creative
 power," is accurate as literally stated but was read, including by the author, as
@@ -121,7 +179,103 @@ No conclusion about biological evolution follows from them.
 
 ---
 
-## Section B. Original text, unaltered
+## Section B. What happens when the experiments are rerun (2026)
+
+Every number below comes from `legacy/summarize.py` reading run manifests. Nothing is
+typed by hand. Reproduce the whole table with:
+
+```
+python legacy/run.py --all --seed 1 --generations 1000
+python legacy/summarize.py --markdown
+```
+
+Five seeds per condition, 1000 generations each, 60 runs total. "2016 set" is the
+original four operators, which can only grow a genome. "all six" adds deletion and
+duplication.
+
+| experiment | operators | selector | seeds | accepted / 1000 | range | bytes |
+|---|---|---|---|---|---|---|
+| abiogenesis | 2016 set | execution only | 5 | 175 (17.5%) | 99-290 | 0 to 146 |
+| abiogenesis | all six | execution only | 5 | 404 (40.4%) | 340-517 | 0 to 101 |
+| beak | 2016 set | test_beak.py | 5 | 43 (4.3%) | 10-66 | 35 to 80 (2.3x) |
+| beak | all six | test_beak.py | 5 | 49 (4.9%) | 29-69 | 35 to 44 (1.2x) |
+| body_plans | 2016 set | test_body_plans.py | 5 | 203 (20.3%) | 181-235 | 1169 to 1416 (1.2x) |
+| body_plans | all six | test_body_plans.py | 5 | 273 (27.3%) | 257-305 | 1169 to 1275 (1.1x) |
+| english | all six | test_english.py | 5 | 292 (29.2%) | 253-388 | 118 to 238 (2.0x) |
+| hello_world_tested | all six | test_hello_world_tested.py | 5 | 472 (47.2%) | 397-535 | 149 to 521 (3.5x) |
+| hello_world_untested | 2016 set | execution only | 5 | 469 (46.9%) | 456-509 | 45 to 938 (20.8x) |
+| hello_world_untested | all six | execution only | 5 | 580 (58.0%) | 553-619 | 45 to 640 (14.2x) |
+| multiple_functions | 2016 set | test_multiple_functions.py | 5 | 35 (3.5%) | 24-52 | 403 to 437 (1.1x) |
+| multiple_functions | all six | test_multiple_functions.py | 5 | 39 (3.9%) | 27-51 | 403 to 420 (1.0x) |
+
+`english` and `hello_world_tested` have no 2016-set rows: those two use pylint as a
+selector and are reported under the recorded pylint version only, for the reason given
+in A6.
+
+### D1. What survives is exactly what something checks
+
+Acceptance rate falls as protection rises, and the ordering is clean:
+
+| experiment | accepted | what protects it |
+|---|---|---|
+| multiple_functions | 3.9% | four functions, each tested, plus an aggregate test |
+| beak | 4.9% | one tested return value in a 35 byte file |
+| body_plans | 27.3% | one of nine branches is reached and tested |
+| english | 29.2% | spell check plus pylint |
+| abiogenesis | 40.4% | nothing; an empty file already exits 0 |
+| hello_world_untested | 58.0% | nothing but syntax |
+
+This is the honest result of the whole project, and it is about software. A mutation
+survives when nothing observes the thing it broke. That is the same statement as
+"surviving mutants indicate weak tests," which is the premise of mutation testing.
+
+### D2. Short-circuit evaluation produces three tiers, not two
+
+The original writeup noticed that branches after the taken one decayed. The rerun shows
+a sharper three-way split. From `results/body_plans/seed-1/end.py`:
+
+```python
+        if self.body_plan == 1:            odf.dengscYriptioYR= self.k8ingddomp+ ...
+        elif self.body_plan == 2:
+            Beff.deT =sZn =eslf.k in idom + '%-=' + 'soi =d wi   xth  495plag 2 ...'
+        elif self.body_plan == 3:
+           self.description = self.kingdom + '-' + 'Body plan 3'
+        elif sqelvod4:
+            sbodiy_plelf.descriIpjn = seTf.kin +'-' ' while Body= 7 ...'
+```
+
+- **Evaluated and executed** (branch 3): condition and body both pristine.
+- **Evaluated but not executed** (branches 1 and 2): the *conditions* survive intact,
+  because they are still evaluated every run and a syntax error there is fatal. The
+  *bodies* are destroyed, because they never execute.
+- **Never evaluated at all** (branches 4 to 9): conditions and bodies both destroyed.
+  Once branch 3 matches, Python stops evaluating, so `elif sqelvod4:` costs nothing.
+
+The middle tier is the interesting one for a working engineer. Those lines are executed
+in the sense that the interpreter reads and evaluates them, they show as covered by
+some tooling, and their contents are still entirely unprotected.
+
+### D3. Deletion slows growth but does not stop it, and raises acceptance
+
+Adding deletion and duplication changes both numbers, in the same direction every time.
+
+Final size falls substantially. On `hello_world_untested`, growth drops from 20.8x to
+14.2x (938 bytes down to 640). On `beak`, from 2.3x to 1.2x. But growth never becomes
+shrinkage, because the three insert-type operators still dominate. This is the measured
+basis for the correction recorded in A3.
+
+Acceptance rate *rises* in every single experiment, most sharply on `abiogenesis`
+(17.5% to 40.4%). Deleting accumulated junk is usually harmless, so more mutations
+survive selection once deletion is available. That was not predicted.
+
+### D4. The beak digit is never hit
+
+Across five seeds and 5000 total generations, the `9` in `beak.py` was never changed to
+another digit. Accepted mutations were whitespace and layout only. See A1.
+
+---
+
+## Section C. Original text, unaltered
 
 The following is the original wiki page as published, preserved verbatim. Image links
 are retained as they appeared and are known to be broken (see A5); regenerated text
@@ -256,7 +410,7 @@ So far, my intuition has been confirmed by these initial test results: random mu
 
 ---
 
-## Section C. Known code defects in this directory
+## Section D. Known code defects in this directory
 
 Preserved as-is; not fixed, since this code is archived.
 

--- a/legacy/run.py
+++ b/legacy/run.py
@@ -25,11 +25,15 @@ import mutate
 HERE = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_RESULTS_ROOT = os.path.join(os.path.dirname(HERE), 'results')
 
-# Files in this directory that are not mutation experiments.
+# Files in this directory that are not mutation experiments. Anything added
+# here that is tooling rather than an experiment must be listed, otherwise it
+# gets mutated. test_run.py asserts the exact expected set, so a new tool fails
+# the suite loudly rather than silently becoming an experiment.
+#
 # self_mutator.py is the abandoned 2017 self-replication attempt. It does not
-# run at all (see legacy/README.md section C) and is the starting point for
+# run at all (see legacy/README.md section D) and is the starting point for
 # phase 2 of the roadmap rather than something to mutate.
-_NOT_EXPERIMENTS = {'mutate.py', 'run.py', 'self_mutator.py'}
+_NOT_EXPERIMENTS = {'mutate.py', 'run.py', 'summarize.py', 'self_mutator.py'}
 
 
 @dataclasses.dataclass
@@ -90,14 +94,38 @@ def _git_sha():
         return None
 
 
-def _prepare_directory(experiment, seed, results_root):
+def run_key(seed, *, legacy_operators=False,
+            span_probability=mutate.DEFAULT_SPAN_PROBABILITY, use_keywords=True):
+    """ Builds the directory name for a run.
+
+        Keyed by seed alone in the common case, so the tree stays readable, but
+        any setting that changes what the experiment does is appended. Without
+        that, a comparison run at the same seed silently overwrites the run it
+        is being compared against.
+    :param seed: Random seed
+    :param legacy_operators: Whether the 2016 operator set was used
+    :param span_probability: Geometric parameter for delete/duplicate spans
+    :param use_keywords: Whether Python keywords are in the mutation alphabet
+    :return: Directory name
+    """
+    key = f'seed-{seed}'
+    if legacy_operators:
+        key += '-legacy'
+    if span_probability != mutate.DEFAULT_SPAN_PROBABILITY:
+        key += f'-span{span_probability:g}'
+    if not use_keywords:
+        key += '-nokeywords'
+    return key
+
+
+def _prepare_directory(experiment, key, results_root):
     """ Creates a clean working directory and copies the experiment into it.
     :param experiment: Experiment name
-    :param seed: Random seed
+    :param key: Directory name from run_key()
     :param results_root: Root directory for all results
     :return: Path to the prepared working directory
     """
-    directory = os.path.join(results_root, experiment, f'seed-{seed}')
+    directory = os.path.join(results_root, experiment, key)
     if os.path.isdir(directory):
         shutil.rmtree(directory)
     os.makedirs(directory)
@@ -131,7 +159,11 @@ def run_experiment(experiment, *, seed, generations,  # pylint: disable=too-many
             f'Unknown experiment {experiment!r}. '
             f'Available: {", ".join(available_experiments())}')
 
-    directory = _prepare_directory(experiment, seed, results_root)
+    directory = _prepare_directory(
+        experiment,
+        run_key(seed, legacy_operators=legacy_operators,
+                span_probability=span_probability, use_keywords=use_keywords),
+        results_root)
     weights = (mutate.LEGACY_MUTATION_WEIGHTS if legacy_operators
                else mutate.DEFAULT_MUTATION_WEIGHTS)
 

--- a/legacy/summarize.py
+++ b/legacy/summarize.py
@@ -1,0 +1,165 @@
+""" summarize.py - turns run manifests into a results table.
+
+The numbers quoted in legacy/README.md come from here rather than being typed by
+hand, so every claim in the writeup traces back to a run directory and a seed.
+
+    python legacy/summarize.py
+    python legacy/summarize.py --results-root results --markdown
+"""
+
+import argparse
+import dataclasses
+import json
+import os
+import statistics
+import sys
+
+DEFAULT_RESULTS_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'results')
+
+
+@dataclasses.dataclass
+class Group:  # pylint: disable=too-many-instance-attributes
+    """ One experimental condition, averaged over its seeds.
+
+        This is a plain record of measured values, so the attribute count
+        reflects how many things a run reports rather than any design problem.
+    """
+    experiment: str
+    operators: str
+    selector: str
+    replicates: int
+    generations: int
+    mean_accepted: float
+    min_accepted: int
+    max_accepted: int
+    mean_start_bytes: float
+    mean_end_bytes: float
+
+    @property
+    def acceptance_rate(self):
+        """ :return: Accepted mutations as a proportion of attempts """
+        return self.mean_accepted / self.generations if self.generations else 0.0
+
+    @property
+    def growth(self):
+        """ :return: End size as a multiple of start size, or None if empty """
+        if not self.mean_start_bytes:
+            return None
+        return self.mean_end_bytes / self.mean_start_bytes
+
+
+def load_runs(results_root=DEFAULT_RESULTS_ROOT):
+    """ Reads every manifest under the results root.
+    :param results_root: Directory containing per-experiment result folders
+    :return: List of manifest dicts
+    """
+    runs = []
+    if not os.path.isdir(results_root):
+        return runs
+    for experiment in sorted(os.listdir(results_root)):
+        experiment_dir = os.path.join(results_root, experiment)
+        if not os.path.isdir(experiment_dir):
+            continue
+        for entry in sorted(os.listdir(experiment_dir)):
+            manifest_path = os.path.join(experiment_dir, entry, 'manifest.json')
+            if not os.path.isfile(manifest_path):
+                continue
+            with open(manifest_path, encoding='utf-8') as handle:
+                runs.append(json.load(handle))
+    return runs
+
+
+def _operator_label(manifest):
+    """ Names the operator set so conditions are not averaged together.
+
+        A run using the 2016 set is a different experiment from one that can
+        delete and duplicate, even at the same seed.
+    :param manifest: A run manifest
+    :return: Human-readable label
+    """
+    weights = manifest.get('operator_weights', {})
+    indels_enabled = weights.get('delete', 0) or weights.get('duplicate', 0)
+    return 'all six' if indels_enabled else '2016 set'
+
+
+def group_runs(runs):
+    """ Groups runs by experiment and operator set, averaging across seeds.
+    :param runs: Manifest dicts from load_runs()
+    :return: Sorted list of Group
+    """
+    buckets = {}
+    for manifest in runs:
+        key = (manifest['experiment'], _operator_label(manifest))
+        buckets.setdefault(key, []).append(manifest)
+
+    groups = []
+    for (experiment, operators), members in sorted(buckets.items()):
+        accepted = [m['successful_mutations'] for m in members]
+        groups.append(Group(
+            experiment=experiment,
+            operators=operators,
+            selector=members[0].get('selector', 'unknown'),
+            replicates=len(members),
+            generations=members[0].get('generations', 0),
+            mean_accepted=statistics.mean(accepted),
+            min_accepted=min(accepted),
+            max_accepted=max(accepted),
+            mean_start_bytes=statistics.mean(m['start_bytes'] for m in members),
+            mean_end_bytes=statistics.mean(m['end_bytes'] for m in members),
+        ))
+    return groups
+
+
+def to_markdown(groups):
+    """ Renders groups as a markdown table.
+    :param groups: List of Group
+    :return: Markdown string
+    """
+    if not groups:
+        return '_No runs found._\n'
+
+    lines = [
+        '| experiment | operators | selector | seeds | accepted / 1000 | range | bytes |',
+        '|---|---|---|---|---|---|---|',
+    ]
+    for group in groups:
+        accepted = f'{group.mean_accepted:.0f} ({group.acceptance_rate:.1%})'
+        span = f'{group.min_accepted}-{group.max_accepted}'
+        size = f'{group.mean_start_bytes:.0f} to {group.mean_end_bytes:.0f}'
+        if group.growth is not None and group.growth != 1:
+            size += f' ({group.growth:.1f}x)'
+        lines.append(f'| {group.experiment} | {group.operators} | {group.selector} '
+                     f'| {group.replicates} | {accepted} | {span} | {size} |')
+    return '\n'.join(lines) + '\n'
+
+
+def main(arguments):
+    """ Entry point for the command line. """
+    parser = argparse.ArgumentParser(description='Summarize mutation experiment runs.')
+    parser.add_argument('--results-root', default=DEFAULT_RESULTS_ROOT,
+                        help='Directory containing results.')
+    parser.add_argument('--markdown', action='store_true',
+                        help='Emit a markdown table for pasting into the writeup.')
+    args = parser.parse_args(arguments)
+
+    groups = group_runs(load_runs(args.results_root))
+    if args.markdown:
+        print(to_markdown(groups), end='')
+        return 0
+
+    if not groups:
+        print('No runs found. Try: python legacy/run.py --all --seed 1')
+        return 1
+    for group in groups:
+        print(f'{group.experiment:22} {group.operators:9} '
+              f'seeds={group.replicates} '
+              f'accepted={group.mean_accepted:7.1f}/{group.generations} '
+              f'({group.acceptance_rate:6.1%}) '
+              f'range={group.min_accepted}-{group.max_accepted} '
+              f'bytes={group.mean_start_bytes:.0f}->{group.mean_end_bytes:.0f}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/legacy/test_run.py
+++ b/legacy/test_run.py
@@ -84,6 +84,27 @@ class TestRunLayout(RunnerTestCase):
         self.assertNotEqual(first.directory, second.directory)
         self.assertEqual(2, len(os.listdir(os.path.join(self.results_root, 'beak'))))
 
+    def test_different_settings_at_the_same_seed_do_not_collide(self):
+        """Otherwise a comparison run silently destroys the run it is being
+        compared against, which is exactly what #18 needs to do."""
+        default = self.go(seed=1)
+        legacy = self.go(seed=1, legacy_operators=True)
+        span = self.go(seed=1, span_probability=0.05)
+        no_keywords = self.go(seed=1, use_keywords=False)
+
+        directories = [default.directory, legacy.directory,
+                       span.directory, no_keywords.directory]
+        self.assertEqual(len(directories), len(set(directories)),
+                         'settings that change the experiment must not share a directory')
+
+    def test_default_settings_keep_the_plain_seed_name(self):
+        """The common case stays readable."""
+        result = self.go(seed=1234)
+        self.assertTrue(result.directory.endswith(os.path.join('beak', 'seed-1234')))
+
+    def test_directory_name_records_the_non_default_setting(self):
+        self.assertIn('legacy', self.go(seed=1, legacy_operators=True).directory)
+
 
 class TestIsolation(RunnerTestCase):
     """The reason run directories exist at all."""

--- a/legacy/test_summarize.py
+++ b/legacy/test_summarize.py
@@ -1,0 +1,131 @@
+"""Tests for the results summarizer.
+
+The point of this tool is that the numbers in legacy/README.md are generated
+from run manifests rather than typed by hand, so a claim in the writeup can
+always be traced back to a run directory and a seed.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+import summarize
+
+
+def write_manifest(root, experiment, key, **fields):
+    """Creates a fake run directory with a manifest."""
+    directory = os.path.join(root, experiment, key)
+    os.makedirs(directory, exist_ok=True)
+    manifest = {
+        'experiment': experiment,
+        'seed': fields.get('seed', 1),
+        'generations': fields.get('generations', 100),
+        'operator_weights': fields.get('operator_weights',
+                                       {'delete': 25, 'duplicate': 25}),
+        'span_probability': 0.3,
+        'use_keywords': True,
+        'selector': fields.get('selector', f'test_{experiment}.py'),
+        'python_version': '3.10.12',
+        'pylint_version': '4.0.6',
+        'git_sha': 'abc123',
+        'successful_mutations': fields.get('successful', 10),
+        'failed_mutations': fields.get('generations', 100) - fields.get('successful', 10),
+        'start_bytes': fields.get('start_bytes', 100),
+        'end_bytes': fields.get('end_bytes', 120),
+    }
+    with open(os.path.join(directory, 'manifest.json'), 'w', encoding='utf-8') as handle:
+        json.dump(manifest, handle)
+    return directory
+
+
+class SummarizeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='mutate-summary-')
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+
+class TestLoading(SummarizeTestCase):
+
+    def test_finds_every_manifest(self):
+        write_manifest(self.root, 'beak', 'seed-1', seed=1)
+        write_manifest(self.root, 'beak', 'seed-2', seed=2)
+        write_manifest(self.root, 'english', 'seed-1', seed=1)
+        self.assertEqual(3, len(summarize.load_runs(self.root)))
+
+    def test_ignores_directories_without_a_manifest(self):
+        write_manifest(self.root, 'beak', 'seed-1')
+        os.makedirs(os.path.join(self.root, 'beak', 'not-a-run'))
+        self.assertEqual(1, len(summarize.load_runs(self.root)))
+
+    def test_missing_root_gives_no_runs(self):
+        self.assertEqual([], summarize.load_runs(os.path.join(self.root, 'nope')))
+
+
+class TestGrouping(SummarizeTestCase):
+
+    def test_separates_operator_sets(self):
+        """Legacy and default runs of the same experiment are different
+        conditions and must not be averaged together."""
+        write_manifest(self.root, 'beak', 'seed-1', seed=1)
+        write_manifest(self.root, 'beak', 'seed-1-legacy', seed=1,
+                       operator_weights={'delete': 0, 'duplicate': 0})
+        groups = summarize.group_runs(summarize.load_runs(self.root))
+        self.assertEqual(2, len(groups))
+        self.assertEqual({('beak', 'all six'), ('beak', '2016 set')},
+                         {(g.experiment, g.operators) for g in groups})
+
+    def test_averages_across_seeds(self):
+        for seed, successful in ((1, 10), (2, 20), (3, 30)):
+            write_manifest(self.root, 'beak', f'seed-{seed}',
+                           seed=seed, successful=successful, generations=100)
+        group = summarize.group_runs(summarize.load_runs(self.root))[0]
+        self.assertEqual(3, group.replicates)
+        self.assertAlmostEqual(20.0, group.mean_accepted, places=5)
+
+    def test_reports_the_range_across_seeds(self):
+        for seed, successful in ((1, 5), (2, 25)):
+            write_manifest(self.root, 'beak', f'seed-{seed}',
+                           seed=seed, successful=successful)
+        group = summarize.group_runs(summarize.load_runs(self.root))[0]
+        self.assertEqual(5, group.min_accepted)
+        self.assertEqual(25, group.max_accepted)
+
+    def test_reports_mean_size_change(self):
+        write_manifest(self.root, 'beak', 'seed-1', seed=1,
+                       start_bytes=100, end_bytes=150)
+        write_manifest(self.root, 'beak', 'seed-2', seed=2,
+                       start_bytes=100, end_bytes=250)
+        group = summarize.group_runs(summarize.load_runs(self.root))[0]
+        self.assertAlmostEqual(100.0, group.mean_start_bytes, places=5)
+        self.assertAlmostEqual(200.0, group.mean_end_bytes, places=5)
+
+    def test_acceptance_rate_is_a_proportion_of_generations(self):
+        write_manifest(self.root, 'beak', 'seed-1', successful=25, generations=100)
+        group = summarize.group_runs(summarize.load_runs(self.root))[0]
+        self.assertAlmostEqual(0.25, group.acceptance_rate, places=5)
+
+
+class TestMarkdown(SummarizeTestCase):
+
+    def test_renders_a_table_with_one_row_per_group(self):
+        write_manifest(self.root, 'beak', 'seed-1', seed=1)
+        write_manifest(self.root, 'english', 'seed-1', seed=1)
+        table = summarize.to_markdown(summarize.group_runs(summarize.load_runs(self.root)))
+        self.assertIn('| beak', table)
+        self.assertIn('| english', table)
+        self.assertIn('---', table)
+
+    def test_names_the_selector(self):
+        write_manifest(self.root, 'abiogenesis', 'seed-1', selector='execution only')
+        table = summarize.to_markdown(summarize.group_runs(summarize.load_runs(self.root)))
+        self.assertIn('execution only', table)
+
+    def test_empty_results_render_without_crashing(self):
+        self.assertIsInstance(summarize.to_markdown([]), str)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #18. Completes phase 1 of #14.

Five seeds at 1000 generations across all seven experiments, plus legacy-operator comparison runs for the five that do not use pylint. 60 runs total.

## New tooling

`legacy/summarize.py` reads run manifests and emits the results table, so every number in the writeup traces back to a run directory and a seed instead of being typed by hand.

```
python legacy/run.py --all --seed 1 --generations 1000
python legacy/summarize.py --markdown
```

## Bug found and fixed

Run directories were keyed on seed alone, so running the same seed with a different operator set **silently overwrote** the earlier result. I hit this immediately when setting up the comparison runs. Directory names now record any non-default setting (`seed-1`, `seed-1-legacy`, `seed-1-span0.05`). Four new tests cover it.

## Findings

**Acceptance rate tracks how much is protected**, and the ordering is clean:

| experiment | accepted | what protects it |
|---|---|---|
| multiple_functions | 3.9% | four tested functions plus an aggregate test |
| beak | 4.9% | one tested return value in a 35 byte file |
| body_plans | 27.3% | one of nine branches reached and tested |
| english | 29.2% | spell check plus pylint |
| abiogenesis | 40.4% | nothing; an empty file already exits 0 |
| hello_world_untested | 58.0% | nothing but syntax |

A mutation survives when nothing observes what it broke. That is the premise of mutation testing stated backwards, and it is the honest result of the whole project.

**Short-circuit evaluation produces three tiers, not two.** The original writeup described branches after the taken one decaying. The rerun shows a sharper split:

- *Evaluated and executed* (branch 3): condition and body pristine.
- *Evaluated but not executed* (branches 1 and 2): **conditions survive intact** because a syntax error there is still fatal, but bodies are destroyed.
- *Never evaluated* (branches 4 to 9): everything destroyed.

The middle tier is the one worth knowing about as an engineer. Those lines are read and evaluated every run, they look reached, and their contents are completely unprotected.

**Deletion cuts growth but never reverses it.** `hello_world_untested` drops from 20.8x to 14.2x growth, `beak` from 2.3x to 1.2x. This is the measured basis for the correction already recorded in A3.

**Deletion raises acceptance in every experiment**, most sharply on `abiogenesis` (17.5% to 40.4%), because deleting accumulated junk is usually harmless. I did not predict this one.

**Beak: the `9` was never changed to another digit across 5000 generations.** Every accepted mutation was whitespace. A1 now rests on an experiment rather than on reading the test.

## Also

New **A6** records that `hello_world_tested` and `english` can never be reproduced as originally run, because pylint acts as a selector and the 2016 version was never recorded. Fresh runs of those two are new measurements, not confirmations.

Sections renumbered so reading order matches the letters: A corrections, B fresh results, C original text, D code defects. Section C prose remains untouched, including its original punctuation.

```
Ran 63 tests in 8.987s
OK
```

All three modules at 10.00/10 under pylint.