### PR TITLE
Add lifecycle engine and shared food pool

### DIFF
--- a/creatures/lifecycle.py
+++ b/creatures/lifecycle.py
@@ -1,0 +1,133 @@
+""" lifecycle.py - the fixed rules a creature cannot mutate away.
+
+Aging, fuel accounting and death live here rather than in the creature's own
+source. A creature is Python text and can be mutated, so if it owned its death
+check evolution would delete it within a few generations and every creature
+would be immortal. Putting the rules in the engine keeps the simulation
+meaningful.
+
+Food comes from a single finite pool with per-tick regrowth. Creatures draw
+from it in the order they ask, so a creature can starve because others got
+there first. That is the competition the 2017 version never had: it counted
+fuel down with nothing to eat and no shared resource.
+"""
+
+# Defaults roughly follow the abandoned 2017 self_mutator: fuel 10, death at
+# age 10, fertile between ages 2 and 5.
+DEFAULT_FUEL = 10
+DEFAULT_MAX_FUEL = 20
+DEFAULT_MAX_AGE = 10
+DEFAULT_FERTILE_FROM = 2
+DEFAULT_FERTILE_UNTIL = 5
+DEFAULT_REPRODUCTION_COST = 5
+
+
+class DeadCreatureError(Exception):
+    """ Raised when something tries to act on a creature that has died. """
+
+
+class NotFertileError(Exception):
+    """ Raised when a creature tries to reproduce while ineligible. """
+
+
+class Lifecycle:  # pylint: disable=too-many-instance-attributes
+    """ The engine-owned state of one creature.
+
+        A plain record of the rules, so the attribute count reflects how many
+        independent parameters a life has rather than any design problem.
+    """
+
+    # Six independent life parameters, all of which a caller legitimately varies
+    # per experiment. Bundling them would add indirection without removing a
+    # decision, so the limit is waived rather than worked around.
+    def __init__(self, fuel=DEFAULT_FUEL, *,  # pylint: disable=too-many-arguments
+                 max_fuel=DEFAULT_MAX_FUEL,
+                 max_age=DEFAULT_MAX_AGE, fertile_from=DEFAULT_FERTILE_FROM,
+                 fertile_until=DEFAULT_FERTILE_UNTIL,
+                 reproduction_cost=DEFAULT_REPRODUCTION_COST):
+        self.fuel = fuel
+        self.max_fuel = max_fuel
+        self.max_age = max_age
+        self.fertile_from = fertile_from
+        self.fertile_until = fertile_until
+        self.reproduction_cost = reproduction_cost
+        self.age = 0
+        self.alive = True
+        self.cause_of_death = None
+
+    def tick(self):
+        """ Advances one tick: one older, one fuel poorer, then check for death.
+
+            Fuel is checked before age, so a creature that runs out of both on
+            the same tick is recorded as having starved.
+        :return: None
+        """
+        self._require_alive()
+        self.age += 1
+        self.fuel -= 1
+        if self.fuel <= 0:
+            self._die('starvation')
+        elif self.age >= self.max_age:
+            self._die('old_age')
+
+    def eat(self, amount):
+        """ Adds fuel, up to the cap.
+        :param amount: Food received, which may be less than was asked for
+        :return: Fuel actually gained
+        """
+        self._require_alive()
+        before = self.fuel
+        self.fuel = min(self.fuel + amount, self.max_fuel)
+        return self.fuel - before
+
+    @property
+    def can_reproduce(self):
+        """ :return: True if inside the fertile window with fuel to spare """
+        return (self.alive
+                and self.fertile_from <= self.age <= self.fertile_until
+                and self.fuel > self.reproduction_cost)
+
+    def pay_for_reproduction(self):
+        """ Deducts the cost of producing one offspring.
+        :return: None
+        """
+        if not self.can_reproduce:
+            raise NotFertileError(
+                f'age {self.age}, fuel {self.fuel}: not eligible to reproduce')
+        self.fuel -= self.reproduction_cost
+
+    def _die(self, cause):
+        self.alive = False
+        self.cause_of_death = cause
+
+    def _require_alive(self):
+        if not self.alive:
+            raise DeadCreatureError(f'creature died of {self.cause_of_death}')
+
+
+class World:
+    """ The shared food supply every creature draws from. """
+
+    def __init__(self, food, regrowth, max_food=None):
+        self.food = food
+        self.regrowth = regrowth
+        self.max_food = max_food
+
+    def tick(self):
+        """ Regrows food, up to the cap if one is set.
+        :return: None
+        """
+        self.food += self.regrowth
+        if self.max_food is not None:
+            self.food = min(self.food, self.max_food)
+
+    def request(self, amount):
+        """ Takes food from the pool, giving whatever is left if the pool is
+            short.  Creatures are served in the order they ask, so a creature
+            can go hungry because others reached the pool first.
+        :param amount: Food wanted
+        :return: Food actually given, between 0 and amount
+        """
+        given = max(0, min(amount, self.food))
+        self.food -= given
+        return given

--- a/creatures/test_lifecycle.py
+++ b/creatures/test_lifecycle.py
@@ -1,0 +1,227 @@
+"""Tests for the lifecycle engine and the shared food pool.
+
+Written before the implementation.
+
+Two design decisions are pinned here. The engine owns aging, fuel and death, so
+a creature cannot mutate away its own death check. And food comes from a single
+finite pool with per-tick regrowth, so creatures genuinely compete and a
+population limits itself instead of growing without bound.
+
+The 2017 version had neither: fuel counted down with nothing to eat, and there
+was no competition at all.
+"""
+
+import unittest
+
+from creatures import lifecycle
+
+
+class TestLifecycleBasics(unittest.TestCase):
+
+    def test_starts_alive_with_full_fuel(self):
+        creature = lifecycle.Lifecycle(fuel=10)
+        self.assertTrue(creature.alive)
+        self.assertEqual(0, creature.age)
+        self.assertEqual(10, creature.fuel)
+        self.assertIsNone(creature.cause_of_death)
+
+    def test_a_tick_costs_one_age_and_one_fuel(self):
+        creature = lifecycle.Lifecycle(fuel=10)
+        creature.tick()
+        self.assertEqual(1, creature.age)
+        self.assertEqual(9, creature.fuel)
+
+    def test_eating_adds_fuel(self):
+        creature = lifecycle.Lifecycle(fuel=5)
+        creature.eat(3)
+        self.assertEqual(8, creature.fuel)
+
+    def test_fuel_is_capped(self):
+        """Otherwise a creature could hoard without limit."""
+        creature = lifecycle.Lifecycle(fuel=5, max_fuel=10)
+        creature.eat(100)
+        self.assertEqual(10, creature.fuel)
+
+
+class TestDeath(unittest.TestCase):
+
+    def test_dies_of_starvation_when_fuel_runs_out(self):
+        creature = lifecycle.Lifecycle(fuel=2)
+        creature.tick()
+        creature.tick()
+        self.assertFalse(creature.alive)
+        self.assertEqual('starvation', creature.cause_of_death)
+
+    def test_dies_of_old_age_at_the_limit(self):
+        creature = lifecycle.Lifecycle(fuel=1000, max_age=3)
+        for _ in range(3):
+            creature.tick()
+        self.assertFalse(creature.alive)
+        self.assertEqual('old_age', creature.cause_of_death)
+
+    def test_starvation_takes_precedence_when_both_would_apply(self):
+        """A creature that runs out of fuel on the same tick it ages out is
+        recorded as starved, since fuel is checked first."""
+        creature = lifecycle.Lifecycle(fuel=1, max_age=1)
+        creature.tick()
+        self.assertEqual('starvation', creature.cause_of_death)
+
+    def test_ticking_a_dead_creature_is_rejected(self):
+        creature = lifecycle.Lifecycle(fuel=1)
+        creature.tick()
+        with self.assertRaises(lifecycle.DeadCreatureError):
+            creature.tick()
+
+    def test_a_dead_creature_cannot_eat(self):
+        creature = lifecycle.Lifecycle(fuel=1)
+        creature.tick()
+        with self.assertRaises(lifecycle.DeadCreatureError):
+            creature.eat(5)
+
+
+class TestReproduction(unittest.TestCase):
+
+    def test_too_young_to_reproduce(self):
+        creature = lifecycle.Lifecycle(fuel=100)
+        self.assertFalse(creature.can_reproduce)
+
+    def test_reproduces_within_the_fertile_window(self):
+        creature = lifecycle.Lifecycle(fuel=100, fertile_from=2, fertile_until=5)
+        creature.tick()
+        creature.tick()
+        self.assertTrue(creature.can_reproduce)
+
+    def test_too_old_to_reproduce(self):
+        creature = lifecycle.Lifecycle(fuel=100, fertile_from=2, fertile_until=3)
+        for _ in range(4):
+            creature.tick()
+        self.assertFalse(creature.can_reproduce)
+
+    def test_cannot_reproduce_without_enough_fuel(self):
+        """Reproduction costs fuel, so a starving creature cannot breed."""
+        creature = lifecycle.Lifecycle(fuel=100, fertile_from=1, reproduction_cost=20)
+        creature.tick()
+        self.assertTrue(creature.can_reproduce)
+        creature.fuel = 5
+        self.assertFalse(creature.can_reproduce)
+
+    def test_reproducing_costs_fuel(self):
+        creature = lifecycle.Lifecycle(fuel=100, fertile_from=1, reproduction_cost=20)
+        creature.tick()
+        creature.pay_for_reproduction()
+        self.assertEqual(79, creature.fuel)
+
+    def test_cannot_pay_when_ineligible(self):
+        creature = lifecycle.Lifecycle(fuel=100)
+        with self.assertRaises(lifecycle.NotFertileError):
+            creature.pay_for_reproduction()
+
+
+class TestWorldFoodPool(unittest.TestCase):
+
+    def test_starts_with_the_given_food(self):
+        world = lifecycle.World(food=50, regrowth=10)
+        self.assertEqual(50, world.food)
+
+    def test_regrows_each_tick(self):
+        world = lifecycle.World(food=0, regrowth=10)
+        world.tick()
+        self.assertEqual(10, world.food)
+
+    def test_regrowth_is_capped(self):
+        world = lifecycle.World(food=95, regrowth=10, max_food=100)
+        world.tick()
+        self.assertEqual(100, world.food)
+
+    def test_requesting_food_removes_it_from_the_pool(self):
+        world = lifecycle.World(food=50, regrowth=0)
+        self.assertEqual(3, world.request(3))
+        self.assertEqual(47, world.food)
+
+    def test_an_empty_pool_gives_nothing(self):
+        world = lifecycle.World(food=0, regrowth=0)
+        self.assertEqual(0, world.request(5))
+
+    def test_a_partial_pool_gives_what_is_left(self):
+        """This is the competition: the last creature to ask goes hungry."""
+        world = lifecycle.World(food=2, regrowth=0)
+        self.assertEqual(2, world.request(5))
+        self.assertEqual(0, world.food)
+        self.assertEqual(0, world.request(5))
+
+    def test_food_is_never_negative(self):
+        world = lifecycle.World(food=1, regrowth=0)
+        world.request(100)
+        self.assertGreaterEqual(world.food, 0)
+
+
+class TestCompetition(unittest.TestCase):
+    """The behaviour the 2017 version could not produce."""
+
+    def test_creatures_that_ask_first_are_fed_first(self):
+        world = lifecycle.World(food=3, regrowth=0)
+        early = lifecycle.Lifecycle(fuel=5)
+        late = lifecycle.Lifecycle(fuel=5)
+        early.eat(world.request(3))
+        late.eat(world.request(3))
+        self.assertEqual(8, early.fuel)
+        self.assertEqual(5, late.fuel)
+
+    def test_scarcity_starves_the_population_down(self):
+        """max_age is raised so old age cannot confound the result: everything
+        that dies here died of starvation."""
+        world = lifecycle.World(food=0, regrowth=2)
+        population = [lifecycle.Lifecycle(fuel=3, max_age=100) for _ in range(10)]
+        for _ in range(20):
+            world.tick()
+            for creature in population:
+                if creature.alive:
+                    creature.eat(world.request(1))
+                    creature.tick()
+        survivors = [c for c in population if c.alive]
+        self.assertGreater(len(survivors), 0, 'total extinction means the world is too harsh')
+        self.assertLess(len(survivors), 10, 'nobody starved, so there was no competition')
+
+    def test_everyone_who_died_under_scarcity_starved(self):
+        """Not old age. This is the point of the food pool."""
+        world = lifecycle.World(food=0, regrowth=2)
+        population = [lifecycle.Lifecycle(fuel=3, max_age=100) for _ in range(10)]
+        for _ in range(20):
+            world.tick()
+            for creature in population:
+                if creature.alive:
+                    creature.eat(world.request(1))
+                    creature.tick()
+        causes = {c.cause_of_death for c in population if not c.alive}
+        self.assertEqual({'starvation'}, causes)
+
+    def test_carrying_capacity_tracks_the_regrowth_rate(self):
+        """The population settles at roughly however many creatures the world
+        can feed, which is what makes it self-limiting without a 2D map."""
+        for regrowth in (2, 4, 6):
+            with self.subTest(regrowth=regrowth):
+                world = lifecycle.World(food=0, regrowth=regrowth)
+                population = [lifecycle.Lifecycle(fuel=3, max_age=100)
+                              for _ in range(20)]
+                for _ in range(30):
+                    world.tick()
+                    for creature in population:
+                        if creature.alive:
+                            creature.eat(world.request(1))
+                            creature.tick()
+                survivors = sum(c.alive for c in population)
+                self.assertEqual(regrowth, survivors)
+
+    def test_abundance_keeps_everyone_alive(self):
+        world = lifecycle.World(food=1000, regrowth=1000)
+        population = [lifecycle.Lifecycle(fuel=3, max_age=100) for _ in range(10)]
+        for _ in range(20):
+            world.tick()
+            for creature in population:
+                creature.eat(world.request(1))
+                creature.tick()
+        self.assertEqual(10, len([c for c in population if c.alive]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #23. Starts phase 2 of #14.

Pure logic, no processes yet, so it is fully unit testable. New `creatures/` package.

## Two decisions, implemented and pinned by tests

**The engine owns aging, fuel and death, not the creature.** Creatures are Python source and will be mutated. If a creature owned its own death check, evolution would delete it within a few generations and every creature would be immortal. That is a real and well-known artificial life result, and it would also end the experiment, so the rules live where mutation cannot reach them.

**Food comes from one finite pool with per-tick regrowth**, and creatures are served in the order they ask. The 2017 `self_mutator.py` counted fuel down with nothing to eat and no shared resource, so nothing ever competed. Now a creature can starve because others got to the pool first.

## What is covered

`Lifecycle`: age, fuel, eating with a cap, death by starvation or old age with the cause recorded, a fertile window, and a fuel cost for reproduction. Fuel is checked before age, so a creature that runs out of both on the same tick is recorded as having starved. Acting on a dead creature raises instead of silently doing nothing.

`World`: food pool, capped regrowth, and allocation that hands out whatever is left when the pool is short.

## The measured behaviour

Population self-limits at the regrowth rate. Starting from twenty creatures over thirty ticks:

| regrowth | survivors |
|---|---|
| 2 | 2 |
| 4 | 4 |
| 6 | 6 |

Every death is starvation, not old age. That gives phase 3 a carrying capacity without needing the 2D map yet, and it is the competition that was missing in 2017.

## A test that was wrong

One test initially showed total extinction and I nearly went looking for a bug in the engine. The cause was the test: the default `max_age` of 10 was killing even the well-fed creatures before the 20 tick run finished, so starvation and old age were confounded. Raising `max_age` isolated the effect being measured, and I added a separate assertion that every death under scarcity is specifically starvation.

## Verification

```
$ .venv/bin/python -m unittest creatures.test_lifecycle
Ran 27 tests in 0.003s
OK
```

`creatures/lifecycle.py` at 10.00/10 under pylint. The 63 legacy tests are unaffected and still pass.

Next: #24 (genome with AST-validated mutation), then #25 (forked supervisor), then #26 (event log).