### PR TITLE
Add creature genome with AST-validated mutation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,7 @@
+# legacy/ is not a package (its modules are imported as top-level names by the
+# experiment test files, which is how the 2016 code worked). creatures/ reuses
+# the mutation operators from legacy/mutate.py deliberately, so that digital
+# organisms and the legacy experiments mutate by exactly the same rules and
+# their results stay comparable.
+[MASTER]
+init-hook='import sys; sys.path.insert(0, "legacy")'

--- a/creatures/genome.py
+++ b/creatures/genome.py
@@ -1,0 +1,181 @@
+""" genome.py - the mutable part of a creature.
+
+A creature is Python source text holding one function, act(), which decides how
+much food to request and whether to reproduce. That is all it owns. Aging,
+fuel accounting and death live in lifecycle.py, where mutation cannot reach
+them, so a creature cannot evolve its way out of dying.
+
+Mutants are checked with ast.parse before anything is spawned, so a syntax
+error costs a parse rather than a forked process. Semantic errors pass the gate
+and kill the creature at runtime, which is the part worth watching.
+
+A child's seed derives from its parent's seed and its birth index. Process
+scheduling is nondeterministic, so a run cannot be reproduced byte for byte,
+but genetics can: the same founder seed and the same birth indices always
+produce the same genomes.
+"""
+
+import ast
+import hashlib
+import random
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                'legacy'))
+
+import mutate  # noqa: E402  pylint: disable=wrong-import-position
+
+# Deliberately minimal: enough to survive and breed so a population exists at
+# all, with obvious room to improve. Anything cleverer would hand the process a
+# strategy it is supposed to find for itself.
+ANCESTOR_SOURCE = '''def act(age, fuel, max_fuel):
+    if fuel < max_fuel / 2:
+        return {'eat': 3, 'reproduce': False}
+    return {'eat': 1, 'reproduce': 2 <= age <= 5}
+'''
+
+class MisbehavingCreatureError(Exception):
+    """ Raised when a creature's act() cannot be called or returns nonsense. """
+
+
+def is_viable(source):
+    """ The spawn gate: can this source be parsed and does it define act()?
+
+        Cheap by design. Rejecting a syntax error here costs a parse instead of
+        a forked process.
+    :param source: Candidate Python source
+    :return: True if the source is worth spawning
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return False
+    return any(isinstance(node, ast.FunctionDef) and node.name == 'act'
+               for node in tree.body)
+
+
+def load(source):
+    """ Executes the source and returns its act() function.
+    :param source: Creature source
+    :return: The act callable
+    """
+    namespace = {}
+    try:
+        exec(source, namespace)  # pylint: disable=exec-used
+    except Exception as error:  # pylint: disable=broad-except
+        raise MisbehavingCreatureError(f'source failed to execute: {error}') from error
+    act = namespace.get('act')
+    if not callable(act):
+        raise MisbehavingCreatureError('source does not define a callable act()')
+    return act
+
+
+def decide(source, *, age, fuel, max_fuel):
+    """ Asks a creature what it wants to do, and never trusts the answer.
+
+        A mutant can return anything at all, so the result is normalised:
+        missing keys take defaults, the food request is clamped into range, and
+        anything non-numeric becomes zero. A creature that raises, returns a
+        non-dict, or has the wrong signature is reported as misbehaving rather
+        than allowed to corrupt the world.
+    :param source: Creature source
+    :param age: Current age in ticks
+    :param fuel: Current fuel
+    :param max_fuel: The creature's fuel ceiling
+    :return: dict with 'eat' (int) and 'reproduce' (bool)
+    """
+    act = load(source)
+    try:
+        raw = act(age, fuel, max_fuel)
+    except Exception as error:  # pylint: disable=broad-except
+        raise MisbehavingCreatureError(f'act() raised: {error}') from error
+
+    if not isinstance(raw, dict):
+        raise MisbehavingCreatureError(f'act() returned {type(raw).__name__}, expected dict')
+
+    return {'eat': _clamp_eat(raw.get('eat', 0), max_fuel),
+            'reproduce': bool(raw.get('reproduce', False))}
+
+
+def _clamp_eat(value, max_fuel):
+    """ Forces a food request into a sane range.
+    :param value: Whatever the creature asked for
+    :param max_fuel: Upper bound on a single request
+    :return: An integer between 0 and max_fuel
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    try:
+        wanted = int(value)
+    except (ValueError, OverflowError):
+        return 0
+    return max(0, min(wanted, max_fuel))
+
+
+def mutate_source(source, seed):
+    """ Produces one mutant of the given source.
+
+        Uses the same six operators as the legacy experiments, including the
+        deletion and duplication added in #16, so genomes here are not
+        restricted to growing the way the 2016 ones were.
+    :param source: Parent source
+    :param seed: Random seed; the same seed always gives the same mutant
+    :return: Mutated source
+    """
+    random.seed(seed)
+    return mutate.Creature._flawed_copy(source)  # pylint: disable=protected-access
+
+
+def _derive_seed(parent_seed, birth_index):
+    """ Derives a child's seed from its parent's seed and birth index.
+
+        Hashed rather than added so sibling seeds are not adjacent, which would
+        otherwise correlate siblings' mutations.
+    :param parent_seed: The parent's seed
+    :param birth_index: Which offspring this is, counting from zero
+    :return: A new seed
+    """
+    digest = hashlib.sha256(f'{parent_seed}:{birth_index}'.encode('utf-8')).digest()
+    return int.from_bytes(digest[:8], 'big')
+
+
+class Genome:
+    """ One creature's heritable material and its place in the lineage. """
+
+    def __init__(self, source, seed, identity, generation):
+        self.source = source
+        self.seed = seed
+        self.identity = identity
+        self.generation = generation
+
+    @classmethod
+    def founder(cls, seed):
+        """ Creates the first creature of a run.
+        :param seed: Founder seed for the whole lineage
+        :return: A Genome carrying the unmutated ancestor
+        """
+        return cls(ANCESTOR_SOURCE, seed, identity='0', generation=1)
+
+    def child(self, birth_index):
+        """ Attempts one offspring. The attempt may fail.
+
+            Exactly one mutation is tried. If the result cannot be parsed, the
+            birth fails and None is returned. It is deliberately not retried:
+            retrying until something valid appears would hide the brittleness
+            of the substrate, which is the quantity this project exists to
+            measure, and no organism gets unlimited attempts at one birth.
+
+            Passing the parse gate is not the same as being alive. Roughly half
+            of mutants that parse still crash when called, and those die in the
+            world rather than here, so the cause of death is recorded honestly.
+        :param birth_index: Which offspring this is, counting from zero
+        :return: A new Genome, or None if the mutant could not be parsed
+        """
+        candidate = mutate_source(self.source, _derive_seed(self.seed, birth_index))
+        if not is_viable(candidate):
+            return None
+        return Genome(source=candidate,
+                      seed=_derive_seed(self.seed, birth_index),
+                      identity=f'{self.identity}.{birth_index}',
+                      generation=self.generation + 1)

--- a/creatures/test_genome.py
+++ b/creatures/test_genome.py
@@ -1,0 +1,253 @@
+"""Tests for the creature genome: source text, mutation, and lineage seeding.
+
+Written before the implementation.
+
+Three things are pinned here.
+
+A creature is Python source holding only its decision behavior. The lifecycle
+rules live in the engine (see lifecycle.py) where mutation cannot reach them.
+
+Mutants are checked with ast.parse before anything is spawned, so a syntax
+error costs a parse rather than a process. Semantic errors still survive the
+gate and kill the creature at runtime, which is the interesting part.
+
+A child's seed derives from its parent's seed and birth index, so the same
+creature always produces the same offspring. Process scheduling is
+nondeterministic but genetics are not, which is what makes a lineage
+reproducible.
+"""
+
+import ast
+import unittest
+
+from creatures import genome
+
+
+class TestAncestor(unittest.TestCase):
+
+    def test_ancestor_is_valid_python(self):
+        ast.parse(genome.ANCESTOR_SOURCE)
+
+    def test_ancestor_exposes_an_act_function(self):
+        loaded = genome.load(genome.ANCESTOR_SOURCE)
+        self.assertTrue(callable(loaded))
+
+    def test_ancestor_returns_a_decision(self):
+        decision = genome.decide(genome.ANCESTOR_SOURCE, age=1, fuel=5, max_fuel=20)
+        self.assertIn('eat', decision)
+        self.assertIn('reproduce', decision)
+
+    def test_ancestor_eats_when_low_on_fuel(self):
+        decision = genome.decide(genome.ANCESTOR_SOURCE, age=1, fuel=1, max_fuel=20)
+        self.assertGreater(decision['eat'], 0)
+
+    def test_ancestor_breeds_inside_the_fertile_window(self):
+        decision = genome.decide(genome.ANCESTOR_SOURCE, age=3, fuel=20, max_fuel=20)
+        self.assertTrue(decision['reproduce'])
+
+    def test_ancestor_does_not_breed_when_too_young(self):
+        decision = genome.decide(genome.ANCESTOR_SOURCE, age=0, fuel=20, max_fuel=20)
+        self.assertFalse(decision['reproduce'])
+
+
+class TestDecisionNormalising(unittest.TestCase):
+    """A mutant can return nonsense. The engine must never trust it."""
+
+    def test_missing_keys_get_defaults(self):
+        source = 'def act(age, fuel, max_fuel):\n    return {}\n'
+        decision = genome.decide(source, age=1, fuel=5, max_fuel=20)
+        self.assertEqual(0, decision['eat'])
+        self.assertFalse(decision['reproduce'])
+
+    def test_negative_eat_is_clamped_to_zero(self):
+        source = 'def act(age, fuel, max_fuel):\n    return {"eat": -50}\n'
+        self.assertEqual(0, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+
+    def test_absurd_eat_is_clamped_to_max_fuel(self):
+        source = 'def act(age, fuel, max_fuel):\n    return {"eat": 10 ** 9}\n'
+        self.assertEqual(20, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+
+    def test_non_numeric_eat_becomes_zero(self):
+        source = 'def act(age, fuel, max_fuel):\n    return {"eat": "lots"}\n'
+        self.assertEqual(0, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+
+    def test_non_dict_return_is_rejected(self):
+        source = 'def act(age, fuel, max_fuel):\n    return 42\n'
+        with self.assertRaises(genome.MisbehavingCreatureError):
+            genome.decide(source, age=1, fuel=5, max_fuel=20)
+
+    def test_raising_creature_is_reported_not_propagated(self):
+        source = 'def act(age, fuel, max_fuel):\n    raise ValueError("boom")\n'
+        with self.assertRaises(genome.MisbehavingCreatureError):
+            genome.decide(source, age=1, fuel=5, max_fuel=20)
+
+    def test_infinite_loop_is_not_our_problem_but_wrong_arity_is(self):
+        source = 'def act(only_one_arg):\n    return {}\n'
+        with self.assertRaises(genome.MisbehavingCreatureError):
+            genome.decide(source, age=1, fuel=5, max_fuel=20)
+
+    def test_missing_act_is_rejected(self):
+        source = 'x = 1\n'
+        with self.assertRaises(genome.MisbehavingCreatureError):
+            genome.decide(source, age=1, fuel=5, max_fuel=20)
+
+
+class TestSyntaxGate(unittest.TestCase):
+    """Invalid mutants must be rejected before anything is spawned."""
+
+    def test_valid_source_passes(self):
+        self.assertTrue(genome.is_viable(genome.ANCESTOR_SOURCE))
+
+    def test_syntax_error_fails(self):
+        self.assertFalse(genome.is_viable('def act(age, fuel, max_fuel)\n  return {}'))
+
+    def test_empty_source_fails(self):
+        self.assertFalse(genome.is_viable(''))
+
+    def test_source_without_act_fails(self):
+        self.assertFalse(genome.is_viable('x = 1\n'))
+
+    def test_gate_never_raises_on_arbitrary_bytes(self):
+        for junk in ('%%%', '\x00\x01', 'def :', 'return', '}{'):
+            with self.subTest(junk=junk):
+                self.assertFalse(genome.is_viable(junk))
+
+
+class TestMutation(unittest.TestCase):
+
+    def test_mutation_changes_the_source(self):
+        mutated = genome.mutate_source(genome.ANCESTOR_SOURCE, seed=1)
+        self.assertNotEqual(genome.ANCESTOR_SOURCE, mutated)
+
+    def test_same_seed_gives_the_same_mutant(self):
+        self.assertEqual(genome.mutate_source(genome.ANCESTOR_SOURCE, seed=7),
+                         genome.mutate_source(genome.ANCESTOR_SOURCE, seed=7))
+
+    def test_different_seeds_give_different_mutants(self):
+        self.assertNotEqual(genome.mutate_source(genome.ANCESTOR_SOURCE, seed=1),
+                            genome.mutate_source(genome.ANCESTOR_SOURCE, seed=2))
+
+    def test_most_mutants_are_rejected_by_the_gate(self):
+        """Python source is brittle. This is the honest baseline: the vast
+        majority of single mutations do not survive parsing."""
+        viable = sum(genome.is_viable(genome.mutate_source(genome.ANCESTOR_SOURCE, seed=s))
+                     for s in range(300))
+        self.assertLess(viable, 250, 'suspiciously tolerant')
+        self.assertGreater(viable, 0, 'nothing survives, so nothing can ever evolve')
+
+
+class TestLineage(unittest.TestCase):
+    """Genetics are reproducible even though process timing is not."""
+
+    @staticmethod
+    def first_viable_child(parent, start=0):
+        """Births can fail, so find one that did not. Which indices succeed is
+        itself deterministic, so this is stable across runs."""
+        for index in range(start, start + 500):
+            child = parent.child(birth_index=index)
+            if child is not None:
+                return index, child
+        raise AssertionError('no viable child in 500 attempts')
+
+    def test_founder_has_generation_one(self):
+        founder = genome.Genome.founder(seed=42)
+        self.assertEqual(1, founder.generation)
+        self.assertEqual('0', founder.identity)
+
+    def test_child_seed_derives_from_parent_and_birth_index(self):
+        founder = genome.Genome.founder(seed=42)
+        first_index, first = self.first_viable_child(founder)
+        _, second = self.first_viable_child(founder, start=first_index + 1)
+        self.assertNotEqual(first.seed, second.seed)
+
+    def test_same_parent_and_index_always_gives_the_same_child(self):
+        index, first = self.first_viable_child(genome.Genome.founder(seed=42))
+        second = genome.Genome.founder(seed=42).child(birth_index=index)
+        self.assertEqual(first.seed, second.seed)
+        self.assertEqual(first.source, second.source)
+        self.assertEqual(first.identity, second.identity)
+
+    def test_different_founder_seeds_give_different_lineages(self):
+        _, first = self.first_viable_child(genome.Genome.founder(seed=1))
+        _, second = self.first_viable_child(genome.Genome.founder(seed=2))
+        self.assertNotEqual(first.seed, second.seed)
+
+    def test_generation_increments_down_the_lineage(self):
+        creature = genome.Genome.founder(seed=42)
+        for _ in range(4):
+            _, creature = self.first_viable_child(creature)
+        self.assertEqual(5, creature.generation)
+
+    def test_identity_records_ancestry(self):
+        founder = genome.Genome.founder(seed=42)
+        child_index, child = self.first_viable_child(founder)
+        grandchild_index, grandchild = self.first_viable_child(child)
+        self.assertEqual('0', founder.identity)
+        self.assertEqual(f'0.{child_index}', child.identity)
+        self.assertEqual(f'0.{child_index}.{grandchild_index}', grandchild.identity)
+
+    def test_a_lineage_replays_identically(self):
+        """The whole point: rerun the same founder seed and get byte-identical
+        genomes back, including which births failed."""
+        def walk():
+            creature = genome.Genome.founder(seed=99)
+            path = []
+            for _ in range(4):
+                _, creature = self.first_viable_child(creature)
+                path.append(creature.source)
+            return path
+
+        self.assertEqual(walk(), walk())
+
+    def test_child_source_is_a_mutant_of_the_parent(self):
+        founder = genome.Genome.founder(seed=42)
+        child = founder.child(birth_index=0)
+        self.assertIsNotNone(child, 'seed 42 index 0 happens to produce a viable child')
+        self.assertNotEqual(founder.source, child.source)
+
+    def test_a_birth_can_fail(self):
+        """Exactly one mutation is attempted per birth. Most fail to parse, and
+        a failed birth produces no offspring rather than being retried."""
+        founder = genome.Genome.founder(seed=42)
+        outcomes = [founder.child(birth_index=i) for i in range(200)]
+        failures = [o for o in outcomes if o is None]
+        successes = [o for o in outcomes if o is not None]
+        self.assertGreater(len(failures), 0, 'no birth ever failed, so the gate does nothing')
+        self.assertGreater(len(successes), 0, 'no birth ever succeeded, so nothing can evolve')
+
+    def test_a_failed_birth_is_reproducible(self):
+        """Whether a given birth fails is part of the genetics, not chance."""
+        first = genome.Genome.founder(seed=42).child(birth_index=5)
+        second = genome.Genome.founder(seed=42).child(birth_index=5)
+        self.assertEqual(first is None, second is None)
+
+    def test_surviving_children_always_parse(self):
+        """The gate's only job: nothing unparseable is ever handed back, so no
+        process is ever forked for something that cannot even be read."""
+        founder = genome.Genome.founder(seed=42)
+        for index in range(50):
+            child = founder.child(birth_index=index)
+            if child is not None:
+                with self.subTest(index=index):
+                    self.assertTrue(genome.is_viable(child.source))
+
+    def test_parsing_is_not_the_same_as_working(self):
+        """Roughly half of mutants that parse still crash when called. Those
+        must reach the world and die there, so the cause is recorded, rather
+        than being filtered out here."""
+        founder = genome.Genome.founder(seed=1)
+        broken = 0
+        for index in range(300):
+            child = founder.child(birth_index=index)
+            if child is None:
+                continue
+            try:
+                genome.decide(child.source, age=3, fuel=5, max_fuel=20)
+            except genome.MisbehavingCreatureError:
+                broken += 1
+        self.assertGreater(broken, 0,
+                           'the gate is filtering out runtime failures it should not')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #24. Part of phase 2 of #14.

A creature is Python source holding one function, `act()`, returning how much food to request and whether to breed. Asking for more food gets more but drains the shared pool faster, so greed is a real strategy with real consequences. Phase 3 extends the same shape by adding a movement key.

The ancestor is deliberately minimal, four lines, per your call: eat when below half fuel, breed inside the fertile window. Enough that a population establishes, with obvious room to improve, without handing over a strategy the process is supposed to find.

The engine **never trusts** what a creature returns. Missing keys take defaults, food requests are clamped, non-numeric values become zero, and a creature that raises or returns the wrong type is reported as misbehaving rather than allowed to corrupt the world.

Child seeds derive from parent seed and birth index via SHA-256, hashed rather than added so sibling seeds are not adjacent and sibling mutations stay uncorrelated.

## Two corrections to my own design

Both found by measuring rather than by reasoning, and both change what the experiment means.

**`child()` originally retried up to 200 times until a mutant parsed.** That hides exactly the brittleness this project exists to measure, and no organism gets 200 attempts at a single birth. It now attempts **once** and returns `None` on failure. Which births fail is deterministic, so lineages still replay identically.

**Passing the parse gate is not the same as being alive, and I had conflated the two.** I ran a lineage and reported it "reached generation 301 without failing". It was broken from **generation 5 onward**: every genome parsed, none of them ran.

```
gen   1: works: {'eat': 3, 'reproduce': False}
gen   5: BROKEN: act() raised: name 'max_fuel' is not defined
gen  10: BROKEN: source failed to execute: name 'x' is not defined
gen 200: BROKEN: source failed to execute: name 'btynrbXCu8KD' is not defined
```

Creatures that parse but crash now reach the world and die there, so the cause of death is recorded honestly instead of being silently filtered out at birth. The parse gate's only remaining job is avoiding the cost of forking a process for something unreadable.

## The honest baseline

Over 2000 attempted births from one founder:

| stage | rate |
|---|---|
| produce a parseable child | 36.6% |
| of those, actually run | 47.4% |
| **overall working offspring** | **17.3%** |

That number is only visible because births are now allowed to fail. Under the old retry-until-success design it would have read as 100%.

## Also

Adds `.pylintrc` so tooling resolves the deliberate reuse of `legacy/mutate.py`. Creatures and the legacy experiments mutate by exactly the same six operators, including the deletion and duplication from #16, so their results stay comparable.

```
$ .venv/bin/python -m unittest creatures.test_lifecycle creatures.test_genome
Ran 62 tests in 0.064s
OK
```

10.00/10 under pylint. The 63 legacy tests are unaffected.

Next: #25, the forked supervisor.