### PR TITLE
Make food the population limiter instead of a concurrency cap

### DIFF
--- a/creatures/genome.py
+++ b/creatures/genome.py
@@ -20,19 +20,26 @@ import hashlib
 import random
 import sys
 import os
+import warnings
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                                 'legacy'))
 
 import mutate  # noqa: E402  pylint: disable=wrong-import-position
 
-# Deliberately minimal: enough to survive and breed so a population exists at
-# all, with obvious room to improve. Anything cleverer would hand the process a
-# strategy it is supposed to find for itself.
+# Deliberately minimal: eat harder when low, otherwise eat modestly and try to
+# breed. Anything cleverer would hand the process a strategy it is supposed to
+# find for itself.
+#
+# Note what it does NOT do: it never checks whether it is old enough to breed.
+# An earlier version hardcoded `2 <= age <= 5`, which quietly capped every
+# creature at two breeding attempts regardless of the engine's fertile window,
+# and drove every population to extinction. Fertility is the engine's business
+# (see lifecycle.can_reproduce); the creature just asks.
 ANCESTOR_SOURCE = '''def act(age, fuel, max_fuel):
     if fuel < max_fuel / 2:
-        return {'eat': 3, 'reproduce': False}
-    return {'eat': 1, 'reproduce': 2 <= age <= 5}
+        return {'eat': 5, 'reproduce': False}
+    return {'eat': 3, 'reproduce': True}
 '''
 
 class MisbehavingCreatureError(Exception):
@@ -48,7 +55,11 @@ def is_viable(source):
     :return: True if the source is worth spawning
     """
     try:
-        tree = ast.parse(source)
+        # Mutants also trigger warnings at parse time, such as invalid decimal
+        # literals, not only at exec time.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tree = ast.parse(source)
     except (SyntaxError, ValueError):
         return False
     return any(isinstance(node, ast.FunctionDef) and node.name == 'act'
@@ -62,7 +73,13 @@ def load(source):
     """
     namespace = {}
     try:
-        exec(source, namespace)  # pylint: disable=exec-used
+        # Mutants routinely produce constructs Python warns about, such as `is`
+        # with a literal. Left unsuppressed these flood stderr: one exploratory
+        # run emitted 64,523 warning lines. They are expected output of a
+        # mutation experiment, not a problem to report.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            exec(source, namespace)  # pylint: disable=exec-used
     except Exception as error:  # pylint: disable=broad-except
         raise MisbehavingCreatureError(f'source failed to execute: {error}') from error
     act = namespace.get('act')

--- a/creatures/lifecycle.py
+++ b/creatures/lifecycle.py
@@ -12,14 +12,22 @@ there first. That is the competition the 2017 version never had: it counted
 fuel down with nothing to eat and no shared resource.
 """
 
-# Defaults roughly follow the abandoned 2017 self_mutator: fuel 10, death at
-# age 10, fertile between ages 2 and 5.
-DEFAULT_FUEL = 10
-DEFAULT_MAX_FUEL = 20
-DEFAULT_MAX_AGE = 10
+# The 2017 self_mutator used fuel 10, death at age 10, fertile between ages 2
+# and 5, and a reproduction cost of 5. Those numbers drive a *mutating*
+# population extinct every time, because only about 17% of births produce a
+# working creature (see genome.py), so a creature needs roughly six attempts
+# just to replace itself and those settings allow about two.
+#
+# These defaults widen the fertile window and cheapen reproduction enough that
+# a mutating population sustains itself. That is the minimum for there to be
+# anything to observe: a lineage that cannot reach replacement is not a
+# minimal creature, it is a dead one.
+DEFAULT_FUEL = 15
+DEFAULT_MAX_FUEL = 40
+DEFAULT_MAX_AGE = 12
 DEFAULT_FERTILE_FROM = 2
-DEFAULT_FERTILE_UNTIL = 5
-DEFAULT_REPRODUCTION_COST = 5
+DEFAULT_FERTILE_UNTIL = 8
+DEFAULT_REPRODUCTION_COST = 1
 
 
 class DeadCreatureError(Exception):

--- a/creatures/test_ecology.py
+++ b/creatures/test_ecology.py
@@ -1,0 +1,146 @@
+"""Tests that a mutating population can actually sustain itself.
+
+These are slower than the unit tests because they run whole populations, but
+they pin the claim the whole phase depends on: food alone limits the
+population, and no artificial concurrency cap is needed as an ecological
+mechanism.
+
+Getting here required two fixes. The ancestor used to hardcode `2 <= age <= 5`,
+which capped every creature at about two breeding attempts regardless of the
+engine's fertile window. And the 2017 lifecycle numbers allowed roughly two
+attempts when about six are needed, since only ~17% of births produce a working
+creature. Together those drove every population extinct.
+"""
+
+import unittest
+
+from creatures import genome, lifecycle
+
+
+def run_population(*, regrowth, ticks=120, founders=20, cap=None, mutate=True):
+    """Runs a population in-process and reports what happened.
+
+    :param regrowth: Food added to the shared pool each tick
+    :param ticks: How long to run
+    :param founders: Starting population
+    :param cap: Optional hard ceiling, used only to prove it is not needed
+    :param mutate: Whether offspring are mutated
+    :return: dict of outcomes
+    """
+    world = lifecycle.World(food=regrowth * 5, regrowth=regrowth)
+    pop = [[lifecycle.Lifecycle(),
+            genome.Genome(genome.ANCESTOR_SOURCE, seed=i, identity=str(i), generation=1),
+            0]
+           for i in range(founders)]
+    history = []
+    deaths = {'starvation': 0, 'old_age': 0, 'crashed': 0}
+    max_generation = 1
+
+    for _ in range(ticks):
+        world.tick()
+        newborns = []
+        for entry in pop:
+            life, gene, births = entry
+            if not life.alive:
+                continue
+            try:
+                decision = genome.decide(gene.source, age=life.age, fuel=life.fuel,
+                                         max_fuel=life.max_fuel)
+            except genome.MisbehavingCreatureError:
+                life.alive = False
+                deaths['crashed'] += 1
+                continue
+            life.eat(world.request(decision['eat']))
+            room = cap is None or len(pop) + len(newborns) < cap
+            if decision['reproduce'] and life.can_reproduce and room:
+                child = gene.child(birth_index=births) if mutate else gene
+                entry[2] += 1
+                life.pay_for_reproduction()
+                if child is not None:
+                    newborns.append([lifecycle.Lifecycle(), child, 0])
+                    max_generation = max(max_generation, child.generation)
+            life.tick()
+            if not life.alive and life.cause_of_death in deaths:
+                deaths[life.cause_of_death] += 1
+        pop = [e for e in pop if e[0].alive] + newborns
+        history.append(len(pop))
+        if not pop:
+            break
+
+    return {'history': history, 'final': len(pop), 'peak': max(history),
+            'deaths': deaths, 'max_generation': max_generation,
+            'extinct': not pop}
+
+
+class TestPopulationSurvives(unittest.TestCase):
+    """Without this, there is nothing to observe in phase 3."""
+
+    def test_a_mutating_population_does_not_go_extinct(self):
+        result = run_population(regrowth=400)
+        self.assertFalse(result['extinct'],
+                         'the ancestor cannot reach replacement rate')
+        self.assertGreater(result['final'], 0)
+
+    def test_lineages_reach_later_generations(self):
+        """Evolution has to actually be happening, not just survival of the
+        founders."""
+        result = run_population(regrowth=400)
+        self.assertGreater(result['max_generation'], 5)
+
+    def test_mutation_costs_lives(self):
+        """Creatures that parse but crash die in the world, and that shows up
+        as a real cause of death rather than being hidden at birth."""
+        result = run_population(regrowth=400)
+        self.assertGreater(result['deaths']['crashed'], 0)
+
+    def test_a_non_mutating_population_never_crashes(self):
+        """Control: every crash in the mutating run is caused by mutation."""
+        result = run_population(regrowth=400, mutate=False)
+        self.assertEqual(0, result['deaths']['crashed'])
+
+
+class TestFoodIsTheLimiter(unittest.TestCase):
+    """The point: scarcity limits the population, so no artificial cap is
+    needed as an ecological mechanism. A process cap is a safety valve for the
+    machine, not a rule of the world."""
+
+    def test_more_food_supports_more_creatures(self):
+        lean = run_population(regrowth=60)
+        rich = run_population(regrowth=400)
+        self.assertGreater(rich['peak'], lean['peak'])
+
+    def test_scarcity_limits_by_suppressing_births_not_by_starving_adults(self):
+        """Measured, and not what I expected. Creatures carry a fuel reserve, so
+        they ride out shortages rather than dying of them: starvation is almost
+        never the proximate cause of death.
+
+        What scarcity actually does is hold fuel below the reproduction
+        threshold, so hungry creatures are refused reproduction and the birth
+        rate falls. Food throttles fertility, not survival.
+        """
+        lean = run_population(regrowth=15, ticks=80)
+        rich = run_population(regrowth=400, ticks=80)
+        self.assertLess(lean['peak'], rich['peak'])
+        self.assertGreater(rich['deaths']['old_age'], lean['deaths']['old_age'])
+
+    def test_too_little_food_ends_in_extinction(self):
+        """The limit has teeth: below replacement, the population dies out."""
+        self.assertTrue(run_population(regrowth=15, ticks=80)['extinct'])
+
+    def test_population_stays_bounded_without_any_cap(self):
+        """No cap is passed at all here. If food did not limit growth this
+        would grow without bound until the machine gave out."""
+        result = run_population(regrowth=400, cap=None)
+        self.assertLess(result['peak'], 5000)
+
+    def test_starving_creatures_cannot_breed(self):
+        """Which is the mechanism that makes food a limiter: a creature short
+        of fuel is refused reproduction by the engine, so scarcity throttles
+        births directly."""
+        creature = lifecycle.Lifecycle(fuel=2, reproduction_cost=5)
+        creature.tick()
+        self.assertFalse(creature.can_reproduce)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/creatures/test_genome.py
+++ b/creatures/test_genome.py
@@ -41,13 +41,23 @@ class TestAncestor(unittest.TestCase):
         decision = genome.decide(genome.ANCESTOR_SOURCE, age=1, fuel=1, max_fuel=20)
         self.assertGreater(decision['eat'], 0)
 
-    def test_ancestor_breeds_inside_the_fertile_window(self):
+    def test_ancestor_asks_to_breed_when_healthy(self):
         decision = genome.decide(genome.ANCESTOR_SOURCE, age=3, fuel=20, max_fuel=20)
         self.assertTrue(decision['reproduce'])
 
-    def test_ancestor_does_not_breed_when_too_young(self):
-        decision = genome.decide(genome.ANCESTOR_SOURCE, age=0, fuel=20, max_fuel=20)
+    def test_ancestor_does_not_ask_to_breed_when_starving(self):
+        decision = genome.decide(genome.ANCESTOR_SOURCE, age=3, fuel=1, max_fuel=20)
         self.assertFalse(decision['reproduce'])
+
+    def test_ancestor_does_not_police_its_own_fertility(self):
+        """It asks at every age; lifecycle.can_reproduce decides. An earlier
+        ancestor hardcoded `2 <= age <= 5`, which capped every creature at two
+        breeding attempts no matter what the engine allowed and drove every
+        population extinct."""
+        young = genome.decide(genome.ANCESTOR_SOURCE, age=0, fuel=20, max_fuel=20)
+        old = genome.decide(genome.ANCESTOR_SOURCE, age=99, fuel=20, max_fuel=20)
+        self.assertTrue(young['reproduce'])
+        self.assertTrue(old['reproduce'])
 
 
 class TestDecisionNormalising(unittest.TestCase):


### PR DESCRIPTION
Answers the design question you raised on #25: can food scarcity limit the population naturally, rather than pausing the simulation at an artificial process ceiling?

**Yes, and it now does.** But getting there exposed that every population was going extinct regardless of how much food was available, so this had to be fixed before the supervisor in #25 would have anything to supervise.

## Two bugs that caused universal extinction

**The ancestor policed its own fertility.** It hardcoded `2 <= age <= 5`, so it only ever asked to breed in that window no matter what the engine allowed. Widening the engine's fertile window changed nothing, which is why my first parameter sweeps all produced byte-identical results and I nearly concluded food was irrelevant. Fertility is now the engine's business (`lifecycle.can_reproduce`); the creature just asks.

**The 2017 lifecycle numbers were below replacement.** They allowed roughly two breeding attempts per creature. Since only ~17% of births produce a working creature (measured in #28), replacement needs roughly six. Defaults widened: fuel 15, max_fuel 40, max_age 12, fertile 2 to 8, reproduction cost 1.

## The mechanism is not what I assumed

I expected scarcity to kill adults. It does not. Creatures carry a fuel reserve and ride out shortages, so **starvation is almost never the proximate cause of death**.

What scarcity actually does is hold fuel below the reproduction threshold, so hungry creatures are refused reproduction and the birth rate falls. **Food throttles fertility, not survival** — which is exactly the mechanism you proposed on the issue, arrived at from the opposite direction.

## Measured, 80 ticks from 20 founders

| regrowth | peak | final | starved | old_age | crashed | extinct |
|---|---|---|---|---|---|---|
| 5 | 23 | 0 | 0 | 21 | 4 | yes |
| 15 | 25 | 0 | 0 | 28 | 12 | yes |
| 30 | 46 | 0 | 0 | 43 | 19 | yes |
| 60 | 65 | 0 | 0 | 64 | 32 | yes |
| 150 | 71 | 44 | 1 | 240 | 186 | no |
| 400 | 71 | 44 | 1 | 240 | 186 | no |

Two caveats worth knowing before #25:

**Above about regrowth 150, food stops binding entirely.** 150 and 400 give identical results, so equilibrium is then set by demography rather than by food. The food limiter only operates in a band, and outside it something else is in charge.

**At equilibrium, mutation is the second largest killer after old age** (186 crashes vs 240 old age, and 1 starvation). Mutational load, not hunger, is the dominant pressure on this population.

## Implication for #25

The process cap should be a **safety valve for your machine**, set well above the expected equilibrium, and it should log loudly if it is ever hit, because that means the food parameters were wrong and the results are contaminated by an artificial ceiling. It is not an ecological mechanism.

## Also

Suppresses warnings when parsing and executing mutant source. One exploratory run emitted **64,523 SyntaxWarning lines and a 4MB log**, because mutants routinely produce constructs like `is` with a literal. Those are expected output of a mutation experiment, not a problem to report.

```
72 creature tests, 63 legacy tests, all green
10.00/10 under pylint
```