### PR TITLE
Add forked supervisor with concurrency cap

### DIFF
--- a/creatures/supervisor.py
+++ b/creatures/supervisor.py
@@ -1,0 +1,308 @@
+""" supervisor.py - forks creatures as real processes and runs the world.
+
+Each creature is one forked process that lives its whole life, blocking briefly
+each tick to be asked for a decision. One fork per creature, not per tick.
+
+Reruns are deliberately not byte-identical: OS scheduling is nondeterministic
+and the order creatures reach the food pool varies. Genetics are reproducible
+(see genome.py), timing is not.
+
+Forking is what makes a mutant survivable. A creature that crashes takes down
+its own process and nothing else, and a creature that hangs can be killed. Both
+are inevitable once source is being mutated, and neither is recoverable if
+creatures run in the supervisor's own process.
+
+The concurrency cap is a safety valve for the machine, not a rule of the world.
+Food is the limiter (see test_ecology.py). If the cap is ever hit in a real
+run, the food parameters were wrong and the results are contaminated by an
+artificial ceiling, so it is counted and reported rather than passed over.
+"""
+
+import json
+import os
+import select
+import signal
+import socket
+import sys
+
+from creatures import genome, lifecycle
+
+# How long a creature gets to answer before it is assumed hung. Generous by CPU
+# standards: deciding is a single function call, so anything slower is looping.
+DEFAULT_TIMEOUT = 0.5
+
+# Safety valve only. Set well above the population the food supply can sustain.
+DEFAULT_MAX_PROCESSES = 500
+
+CAUSES = ('starvation', 'old_age', 'crashed', 'timeout')
+
+
+class Creature:  # pylint: disable=too-few-public-methods
+    """ One living creature: its process, its pipe, and its engine state.
+
+        A record binding a pid to a genome and its engine state; the behaviour
+        lives on Supervisor, which owns every creature.
+    """
+
+    def __init__(self, pid, channel, gene, life, birth_index=0):
+        self.pid = pid
+        self.channel = channel
+        self.gene = gene
+        self.life = life
+        self.births = birth_index
+
+    def close(self):
+        """ Closes this creature's end of the pipe. """
+        try:
+            self.channel.close()
+        except OSError:
+            pass
+
+
+def _child_loop(channel, source):
+    """ Runs inside the forked process for the whole of a creature's life.
+
+        Reads one request per tick, answers with a decision, and exits when the
+        supervisor closes the pipe or says to die. Any failure is reported as an
+        error reply rather than a traceback, so the supervisor can record a
+        cause of death instead of guessing from an exit code.
+    :param channel: Socket to the supervisor
+    :param source: This creature's genome source
+    :return: Never; always exits the process
+    """
+    reader = channel.makefile('r')
+    writer = channel.makefile('w')
+    try:
+        for line in reader:
+            request = json.loads(line)
+            if request.get('cmd') == 'die':
+                break
+            try:
+                reply = genome.decide(source,
+                                      age=request['age'],
+                                      fuel=request['fuel'],
+                                      max_fuel=request['max_fuel'])
+            except genome.MisbehavingCreatureError as error:
+                reply = {'error': str(error)}
+            writer.write(json.dumps(reply) + '\n')
+            writer.flush()
+    except (OSError, ValueError):
+        pass
+    finally:
+        os._exit(0)  # pylint: disable=protected-access
+
+
+class Supervisor:  # pylint: disable=too-many-instance-attributes
+    """ Owns the world, the population, and every creature process.
+
+        The attribute count reflects how many independent things a run tracks:
+        world parameters, the population, and four separate tallies.
+    """
+
+    # Eight world parameters, all of which an experiment legitimately varies.
+    def __init__(self, *, regrowth=100, food=None,  # pylint: disable=too-many-arguments
+                 max_processes=DEFAULT_MAX_PROCESSES,
+                 timeout=DEFAULT_TIMEOUT, max_age=lifecycle.DEFAULT_MAX_AGE,
+                 max_fuel=lifecycle.DEFAULT_MAX_FUEL,
+                 starting_fuel=lifecycle.DEFAULT_FUEL):
+        self.world = lifecycle.World(
+            food=regrowth * 5 if food is None else food, regrowth=regrowth)
+        self.max_processes = max_processes
+        self.timeout = timeout
+        self.max_age = max_age
+        self.max_fuel = max_fuel
+        self.starting_fuel = starting_fuel
+
+        self.living = []
+        self.deaths = dict.fromkeys(CAUSES, 0)
+        self.births = 0
+        self.cap_hits = 0
+        self.ticks = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.shutdown()
+        return False
+
+    def _new_life(self):
+        return lifecycle.Lifecycle(fuel=self.starting_fuel, max_fuel=self.max_fuel,
+                                   max_age=self.max_age)
+
+    def spawn(self, gene):
+        """ Forks a new creature process.
+        :param gene: The Genome the creature will run
+        :return: The Creature, already added to the living population
+        """
+        parent_end, child_end = socket.socketpair()
+        pid = os.fork()
+        if pid == 0:
+            parent_end.close()
+            _child_loop(child_end, gene.source)
+        child_end.close()
+        creature = Creature(pid, parent_end, gene, self._new_life())
+        self.living.append(creature)
+        return creature
+
+    def start(self, founders, seed):
+        """ Spawns the founding population.
+        :param founders: How many founders to create
+        :param seed: Founder seed; each founder gets seed + its index
+        :return: None
+        """
+        for index in range(founders):
+            self.spawn(genome.Genome.founder(seed=seed + index))
+
+    # Seven ways a creature can fail to answer usefully, each needing its own
+    # early exit. Collapsing them would only hide which one happened.
+    def ask(self, creature):  # pylint: disable=too-many-return-statements
+        """ Asks one creature for its decision, enforcing the timeout.
+        :param creature: The Creature to ask
+        :return: A decision dict, or None if it crashed, hung or went silent
+        """
+        request = json.dumps({'cmd': 'tick',
+                              'age': creature.life.age,
+                              'fuel': creature.life.fuel,
+                              'max_fuel': creature.life.max_fuel}) + '\n'
+        try:
+            creature.channel.sendall(request.encode('utf-8'))
+        except OSError:
+            return None
+
+        ready, _, _ = select.select([creature.channel], [], [], self.timeout)
+        if not ready:
+            return 'timeout'
+        try:
+            raw = creature.channel.recv(65536)
+        except OSError:
+            return None
+        if not raw:
+            return None
+        try:
+            reply = json.loads(raw.decode('utf-8').splitlines()[0])
+        except (ValueError, IndexError):
+            return None
+        if 'error' in reply:
+            return None
+        return reply
+
+    def _kill(self, creature, cause):
+        """ Ends a creature: records the cause, kills the process, reaps it. """
+        self.deaths[cause] += 1
+        creature.close()
+        try:
+            os.kill(creature.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            os.waitpid(creature.pid, 0)
+        except ChildProcessError:
+            pass
+
+    def tick(self):
+        """ Advances the world one tick.
+
+            Food regrows, then every creature is asked in turn what it wants.
+            Creatures are served in the order they are asked, so a creature can
+            go hungry because others reached the pool first.
+        :return: None
+        """
+        self.ticks += 1
+        self.world.tick()
+        newborns = []
+
+        for creature in list(self.living):
+            decision = self.ask(creature)
+            if decision == 'timeout':
+                self.living.remove(creature)
+                self._kill(creature, 'timeout')
+                continue
+            if decision is None:
+                self.living.remove(creature)
+                self._kill(creature, 'crashed')
+                continue
+
+            creature.life.eat(self.world.request(decision['eat']))
+            if decision['reproduce'] and creature.life.can_reproduce:
+                # Newborns are not spawned until the end of the tick, so they
+                # must be counted against the cap here or several births in one
+                # tick can each pass the check and collectively overshoot it.
+                newborns.append(self._breed(creature, pending=len(newborns)))
+            creature.life.tick()
+            if not creature.life.alive:
+                self.living.remove(creature)
+                self._kill(creature, creature.life.cause_of_death)
+
+        for gene in filter(None, newborns):
+            self.spawn(gene)
+
+    def _breed(self, creature, pending):
+        """ Attempts one birth, respecting the process cap.
+        :param creature: The parent
+        :param pending: Births already agreed this tick but not yet spawned
+        :return: The child Genome, or None if the birth failed or was capped
+        """
+        if len(self.living) + pending >= self.max_processes:
+            self.cap_hits += 1
+            return None
+        child = creature.gene.child(birth_index=creature.births)
+        creature.births += 1
+        creature.life.pay_for_reproduction()
+        if child is None:
+            return None
+        self.births += 1
+        return child
+
+    def shutdown(self):
+        """ Kills and reaps every remaining creature. Safe to call twice.
+        :return: None
+        """
+        for creature in self.living:
+            creature.close()
+            try:
+                os.kill(creature.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+        for creature in self.living:
+            try:
+                os.waitpid(creature.pid, 0)
+            except (ChildProcessError, OSError):
+                pass
+        self.living = []
+
+    def summary(self):
+        """ :return: A dict describing how the run went """
+        return {'ticks': self.ticks, 'living': len(self.living),
+                'births': self.births, 'deaths': dict(self.deaths),
+                'cap_hits': self.cap_hits, 'food': self.world.food}
+
+
+def main(arguments):
+    """ Entry point for the command line. """
+    import argparse  # pylint: disable=import-outside-toplevel
+    parser = argparse.ArgumentParser(description='Run a population of forked creatures.')
+    parser.add_argument('--ticks', type=int, default=50)
+    parser.add_argument('--founders', type=int, default=10)
+    parser.add_argument('--seed', type=int, default=1)
+    parser.add_argument('--regrowth', type=int, default=400)
+    parser.add_argument('--max-processes', type=int, default=DEFAULT_MAX_PROCESSES)
+    args = parser.parse_args(arguments)
+
+    with Supervisor(regrowth=args.regrowth, max_processes=args.max_processes) as sup:
+        sup.start(founders=args.founders, seed=args.seed)
+        for tick in range(args.ticks):
+            sup.tick()
+            print(f'tick {tick:4}  living {len(sup.living):4}  food {sup.world.food:6}')
+            if not sup.living:
+                print('extinct')
+                break
+        print(sup.summary())
+        if sup.cap_hits:
+            print(f'WARNING: process cap hit {sup.cap_hits} times. Food parameters '
+                  f'were wrong and these results are capped by an artificial ceiling.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/creatures/test_supervisor.py
+++ b/creatures/test_supervisor.py
@@ -1,0 +1,248 @@
+"""Tests for the forked supervisor.
+
+Written before the implementation.
+
+Each creature is a real OS process that lives its whole life, blocking briefly
+each tick to be asked for a decision. One fork per creature, not per tick.
+
+Byte-identical reruns are explicitly not a goal, because process scheduling is
+nondeterministic. Genetics are reproducible; timing is not.
+
+The parts most worth testing are the ones that stalled this work in 2017: the
+concurrency cap, orphaned processes, and creatures that never answer. A mutant
+containing `while True` is not hypothetical, it is inevitable.
+"""
+
+import os
+import signal
+import time
+import unittest
+
+from creatures import genome, lifecycle, supervisor
+
+
+def alive(pid):
+    """:return: True if the process exists and has not been reaped."""
+    try:
+        finished, _ = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        return False
+    return finished == 0
+
+
+class SupervisorTestCase(unittest.TestCase):
+    """Every test tears its processes down, so a failure cannot leak children."""
+
+    def setUp(self):
+        self.supervisors = []
+
+    def tearDown(self):
+        for sup in self.supervisors:
+            sup.shutdown()
+
+    def make(self, **kwargs):
+        kwargs.setdefault('regrowth', 400)
+        kwargs.setdefault('max_processes', 50)
+        sup = supervisor.Supervisor(**kwargs)
+        self.supervisors.append(sup)
+        return sup
+
+
+class TestSpawning(SupervisorTestCase):
+
+    def test_spawning_creates_a_real_process(self):
+        sup = self.make()
+        creature = sup.spawn(genome.Genome.founder(seed=1))
+        self.assertNotEqual(os.getpid(), creature.pid)
+        self.assertTrue(alive(creature.pid))
+
+    def test_founders_are_spawned_on_start(self):
+        sup = self.make()
+        sup.start(founders=3, seed=1)
+        self.assertEqual(3, len(sup.living))
+
+    def test_a_creature_answers_a_tick(self):
+        sup = self.make()
+        creature = sup.spawn(genome.Genome.founder(seed=1))
+        decision = sup.ask(creature)
+        self.assertIn('eat', decision)
+        self.assertIn('reproduce', decision)
+
+    def test_shutdown_leaves_no_processes_behind(self):
+        sup = self.make()
+        sup.start(founders=5, seed=1)
+        pids = [c.pid for c in sup.living]
+        sup.shutdown()
+        time.sleep(0.2)
+        for pid in pids:
+            with self.subTest(pid=pid):
+                self.assertFalse(alive(pid), 'orphaned process left running')
+
+
+class TestTicking(SupervisorTestCase):
+
+    def test_a_tick_ages_every_creature(self):
+        sup = self.make()
+        sup.start(founders=3, seed=1)
+        sup.tick()
+        for creature in sup.living:
+            self.assertEqual(1, creature.life.age)
+
+    def test_food_is_consumed_from_the_shared_pool(self):
+        sup = self.make(regrowth=0, food=100)
+        sup.start(founders=3, seed=1)
+        sup.tick()
+        self.assertLess(sup.world.food, 100)
+
+    def test_creatures_die_and_are_reaped(self):
+        sup = self.make(max_age=2)
+        sup.start(founders=3, seed=1)
+        pids = [c.pid for c in sup.living]
+        for _ in range(3):
+            sup.tick()
+        self.assertEqual(0, len(sup.living))
+        time.sleep(0.2)
+        for pid in pids:
+            with self.subTest(pid=pid):
+                self.assertFalse(alive(pid))
+
+    def test_deaths_are_recorded_with_a_cause(self):
+        sup = self.make(max_age=2)
+        sup.start(founders=3, seed=1)
+        for _ in range(3):
+            sup.tick()
+        self.assertEqual(3, sup.deaths['old_age'])
+
+    def test_population_reproduces(self):
+        sup = self.make()
+        sup.start(founders=5, seed=1)
+        for _ in range(6):
+            sup.tick()
+        self.assertGreater(sup.births, 0)
+
+
+class TestMisbehavingCreatures(SupervisorTestCase):
+    """The failure modes that only appear once mutants are running."""
+
+    def test_a_creature_that_crashes_is_killed_and_recorded(self):
+        sup = self.make()
+        broken = genome.Genome('def act(age, fuel, max_fuel):\n    raise ValueError("x")\n',
+                               seed=1, identity='0', generation=1)
+        creature = sup.spawn(broken)
+        sup.tick()
+        self.assertEqual(1, sup.deaths['crashed'])
+        time.sleep(0.2)
+        self.assertFalse(alive(creature.pid))
+
+    def test_a_creature_that_hangs_is_killed_and_recorded_as_timeout(self):
+        """A mutant containing `while True` is inevitable. It must not stall
+        the whole run, and it must be distinguishable from a crash."""
+        sup = self.make(timeout=0.25)
+        hung = genome.Genome('def act(age, fuel, max_fuel):\n'
+                             '    while True:\n        pass\n',
+                             seed=1, identity='0', generation=1)
+        creature = sup.spawn(hung)
+        started = time.monotonic()
+        sup.tick()
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(1, sup.deaths['timeout'])
+        self.assertLess(elapsed, 5.0, 'the tick stalled instead of timing out')
+        time.sleep(0.2)
+        self.assertFalse(alive(creature.pid), 'hung process was not killed')
+
+    def test_a_timeout_is_not_counted_as_a_crash(self):
+        sup = self.make(timeout=0.25)
+        sup.spawn(genome.Genome('def act(age, fuel, max_fuel):\n'
+                                '    while True:\n        pass\n',
+                                seed=1, identity='0', generation=1))
+        sup.tick()
+        self.assertEqual(0, sup.deaths['crashed'])
+
+    def test_one_bad_creature_does_not_kill_the_others(self):
+        """Process isolation is the whole reason for forking."""
+        sup = self.make(timeout=0.25)
+        sup.start(founders=3, seed=1)
+        sup.spawn(genome.Genome('def act(age, fuel, max_fuel):\n'
+                                '    while True:\n        pass\n',
+                                seed=99, identity='x', generation=1))
+        sup.tick()
+        self.assertEqual(3, len(sup.living))
+
+
+class TestConcurrencyCap(SupervisorTestCase):
+    """The cap is a safety valve for the machine, not an ecological rule.
+    Food is the limiter (see test_ecology.py)."""
+
+    def test_the_cap_is_never_exceeded(self):
+        sup = self.make(max_processes=8)
+        sup.start(founders=5, seed=1)
+        for _ in range(10):
+            sup.tick()
+            self.assertLessEqual(len(sup.living), 8)
+
+    def test_hitting_the_cap_is_recorded_as_a_warning(self):
+        """If this ever fires in a real run the food parameters were wrong and
+        the results are contaminated by an artificial ceiling."""
+        sup = self.make(max_processes=6)
+        sup.start(founders=5, seed=1)
+        for _ in range(10):
+            sup.tick()
+        self.assertGreater(sup.cap_hits, 0)
+
+    def test_a_generous_cap_is_never_hit(self):
+        sup = self.make(max_processes=500, regrowth=100)
+        sup.start(founders=5, seed=1)
+        for _ in range(10):
+            sup.tick()
+        self.assertEqual(0, sup.cap_hits)
+
+
+class TestCleanShutdown(SupervisorTestCase):
+
+    def test_shutdown_is_idempotent(self):
+        sup = self.make()
+        sup.start(founders=3, seed=1)
+        sup.shutdown()
+        sup.shutdown()
+
+    def test_shutdown_works_from_a_context_manager(self):
+        with supervisor.Supervisor(regrowth=400, max_processes=50) as sup:
+            sup.start(founders=3, seed=1)
+            pids = [c.pid for c in sup.living]
+        time.sleep(0.2)
+        for pid in pids:
+            with self.subTest(pid=pid):
+                self.assertFalse(alive(pid))
+
+    def test_children_survive_a_signal_to_the_group_being_handled(self):
+        """Children must not be killable out from under the supervisor by a
+        stray signal to the process group, and must still be reapable."""
+        sup = self.make()
+        sup.start(founders=2, seed=1)
+        for creature in sup.living:
+            os.kill(creature.pid, signal.SIGTERM)
+        time.sleep(0.2)
+        sup.tick()
+        self.assertEqual(0, len(sup.living))
+
+
+class TestWorldWiring(SupervisorTestCase):
+
+    def test_world_regrows_each_tick(self):
+        sup = self.make(regrowth=50, food=0)
+        sup.start(founders=0, seed=1)
+        sup.tick()
+        self.assertEqual(50, sup.world.food)
+
+    def test_lifecycle_parameters_reach_the_creatures(self):
+        sup = self.make(max_age=99)
+        sup.start(founders=1, seed=1)
+        self.assertEqual(99, sup.living[0].life.max_age)
+
+    def test_world_is_a_lifecycle_world(self):
+        self.assertIsInstance(self.make().world, lifecycle.World)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #25. This is the piece that stalled the work in 2017.

Each creature is one real OS process that lives its whole life, blocking briefly each tick to be asked for a decision over a socketpair. One fork per creature, not per tick.

**Forking is what makes mutants survivable.** A creature that crashes takes down only its own process; a creature that hangs can be killed. Neither is recoverable if creatures run in the supervisor's own process, and both are inevitable once source is being mutated.

Hung creatures are killed on a timeout and recorded as `timeout`, their own cause of death alongside `starvation`, `old_age` and `crashed`, so a runaway loop becomes a statistic rather than a stall.

The process cap is a **safety valve for the machine**, not a rule of the world. Food is the limiter. If the cap is ever hit, the run prints a warning saying the food parameters were wrong and the results are capped by an artificial ceiling.

## A bug the tests caught

The cap was checked per birth against the living population, but newborns are not spawned until the end of a tick, so several births in one tick each passed the check and collectively overshot it (9 living against a cap of 8). Pending births are now counted.

## A real run

40 ticks, 10 founders, regrowth 400:

```
{'ticks': 40, 'living': 19, 'births': 123,
 'deaths': {'starvation': 0, 'old_age': 55, 'crashed': 59, 'timeout': 0},
 'cap_hits': 0, 'food': 15714}
processes after: 0
```

Population stable around 19, no orphans, no cap hits.

## Two things phase 3 needs to know

**Mutation is roughly half of all mortality**: 59 crashes against 55 old-age deaths, and zero starvation. Mutational load, not hunger, is the dominant pressure.

**The food limiter operates in a narrow band.** Measured across three regrowth rates:

| regrowth | outcome |
|---|---|
| 20 | extinct at tick 21 |
| 60 | stable at 19, identical to 400 |
| 400 | stable at 19 |

60 and 400 produce **byte-identical** results, so above roughly 60 food stops binding entirely and equilibrium is set by demography. Phase 3 parameters need to sit inside that band or the food supply is decorative. Incidentally, identical results across a nondeterministic forked run is a useful sanity check that ordering only matters when food is actually scarce.

**No timeouts occurred in any run**, so infinite-loop mutants are rarer than I expected from this ancestor. That path is covered by tests rather than by observation, which is worth knowing if it ever starts firing.

## Tests

22 supervisor tests: spawning real processes, ticking, crashes, hangs, process isolation (one bad creature must not kill the others), the cap, orphan cleanup, idempotent shutdown, and context-manager teardown.

```
94 creature tests, 63 legacy tests, all green
10.00/10 under pylint
```

Next: #26, the event log and rerun.