### PR TITLE
Add event log, run manifest and replay

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,3 +5,9 @@
 # their results stay comparable.
 [MASTER]
 init-hook='import sys; sys.path.insert(0, "legacy")'
+
+[BASIC]
+# Test methods and Test classes carry their description in the name, and most
+# already have a docstring where the intent is not obvious. Requiring one on
+# every test adds noise without adding information.
+no-docstring-rgx=^(_|test_|Test)

--- a/creatures/events.py
+++ b/creatures/events.py
@@ -1,0 +1,225 @@
+""" events.py - the record of what happened in a run.
+
+Forked runs cannot be reproduced byte for byte: OS scheduling decides which
+creature reaches the food pool first, so rerunning the same seed gives a
+similar run, not the same one. Genetics are reproducible (see genome.py);
+timing is not.
+
+So rather than re-running to find out what happened, every run writes down what
+happened as it goes. The log is append-only JSON lines, one event per line,
+which survives a run being killed halfway through and can be read back without
+spawning a single process.
+
+That matters twice: analysis stops depending on luck, and phase 4 can animate a
+run from its log rather than by re-running it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+class EventLog:
+    """ Append-only writer for one run's events. """
+
+    def __init__(self, path):
+        self.path = path
+        self._handle = None
+
+    def __enter__(self):
+        directory = os.path.dirname(self.path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        self._handle = open(self.path, 'a', encoding='utf-8')  # pylint: disable=consider-using-with
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+        return False
+
+    def close(self):
+        """ Closes the log. Safe to call more than once. """
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def _write(self, kind, tick, **fields):
+        record = {'kind': kind, 'tick': tick}
+        record.update(fields)
+        self._handle.write(json.dumps(record, sort_keys=True) + '\n')
+        self._handle.flush()
+
+    def birth(self, *, tick, identity, generation, parent):
+        """ Records a creature being born. """
+        self._write('birth', tick, identity=identity, generation=generation,
+                    parent=parent)
+
+    def death(self, *, tick, identity, cause, age, generation):
+        """ Records a creature dying, and why. """
+        self._write('death', tick, identity=identity, cause=cause, age=age,
+                    generation=generation)
+
+    def birth_failed(self, *, tick, parent, reason):
+        """ Records a birth that produced nothing.
+
+            'unparseable' means the mutant could not be parsed, which is the
+            measurement of how brittle the substrate is. 'capped' means the
+            process ceiling was hit, which means the food parameters were wrong.
+        """
+        self._write('birth_failed', tick, parent=parent, reason=reason)
+
+    def snapshot(self, *, tick, population, food):
+        """ Records aggregate world state at the end of a tick. """
+        self._write('snapshot', tick, population=population, food=food)
+
+
+def read(path):
+    """ Reads a log back.
+
+        A run killed mid-write leaves a truncated final line. That line is
+        skipped rather than treated as fatal, so an interrupted run is still
+        analysable.
+    :param path: Path to an events.jsonl
+    :return: List of event dicts
+    """
+    if not os.path.isfile(path):
+        return []
+    records = []
+    with open(path, encoding='utf-8') as handle:
+        for line in handle:
+            try:
+                records.append(json.loads(line))
+            except ValueError:
+                continue
+    return records
+
+
+class Replay:
+    """ Reconstructs a run from its log, without running anything. """
+
+    def __init__(self, path):
+        self.events = read(path)
+
+    @property
+    def population_over_time(self):
+        """ :return: Population at the end of each tick """
+        return [e['population'] for e in self.events if e['kind'] == 'snapshot']
+
+    @property
+    def food_over_time(self):
+        """ :return: Food in the pool at the end of each tick """
+        return [e['food'] for e in self.events if e['kind'] == 'snapshot']
+
+    @property
+    def births(self):
+        """ :return: How many creatures were born """
+        return sum(1 for e in self.events if e['kind'] == 'birth')
+
+    @property
+    def failed_births(self):
+        """ :return: How many births produced nothing """
+        return sum(1 for e in self.events if e['kind'] == 'birth_failed')
+
+    @property
+    def birth_failure_rate(self):
+        """ How often a birth produced nothing. With 'unparseable' as the usual
+            reason, this is the substrate's brittleness measured in situ.
+        :return: Failed births as a proportion of all attempts, or 0.0
+        """
+        attempts = self.births + self.failed_births
+        return self.failed_births / attempts if attempts else 0.0
+
+    @property
+    def deaths(self):
+        """ :return: Count of deaths by cause """
+        counts = {}
+        for event in self.events:
+            if event['kind'] == 'death':
+                counts[event['cause']] = counts.get(event['cause'], 0) + 1
+        return counts
+
+    @property
+    def deepest_generation(self):
+        """ :return: The furthest any lineage got from the founders """
+        return max((e['generation'] for e in self.events
+                    if e['kind'] in ('birth', 'death')), default=0)
+
+    def living_at(self, tick):
+        """ Who was alive at the end of a given tick.
+
+            Phase 4 needs this to draw a frame without re-running the
+            simulation.
+        :param tick: The tick of interest
+        :return: Set of creature identities
+        """
+        living = set()
+        for event in self.events:
+            if event['tick'] > tick:
+                break
+            if event['kind'] == 'birth':
+                living.add(event['identity'])
+            elif event['kind'] == 'death':
+                living.discard(event['identity'])
+        return living
+
+
+def _git_sha():
+    """ :return: Current commit SHA, or None outside a git checkout """
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], cwd=HERE,
+            stderr=subprocess.DEVNULL).strip().decode('utf-8')
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+
+# Seven run parameters plus the summary, all of which belong in the record.
+def write_manifest(path, *, seed, ticks, founders,  # pylint: disable=too-many-arguments
+                   regrowth, max_processes, timeout, summary):
+    """ Records everything needed to set a run up again.
+    :param path: Where to write manifest.json
+    :param seed: Founder seed
+    :param ticks: How many ticks were requested
+    :param founders: Starting population
+    :param regrowth: Food added per tick
+    :param max_processes: The safety cap
+    :param timeout: Seconds a creature gets to answer
+    :param summary: Outcome counters from the run
+    :return: The manifest dict that was written
+    """
+    manifest = {
+        'seed': seed,
+        'ticks': ticks,
+        'founders': founders,
+        'regrowth': regrowth,
+        'max_processes': max_processes,
+        'timeout': timeout,
+        'git_sha': _git_sha(),
+        'python_version': sys.version.split()[0],
+        'summary': summary,
+        'reproducibility': (
+            'Genetics are reproducible: the same seed always produces the same '
+            'genomes. Timing is not, because OS scheduling decides which '
+            'creature reaches the food pool first. Rerunning these parameters '
+            'gives a statistically similar run, not an identical one. Use '
+            'events.jsonl for what actually happened.'),
+    }
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write('\n')
+    return manifest
+
+
+def read_manifest(path):
+    """ Reads a manifest back.
+    :param path: Path to manifest.json
+    :return: The manifest dict
+    """
+    with open(path, encoding='utf-8') as handle:
+        return json.load(handle)

--- a/creatures/genome.py
+++ b/creatures/genome.py
@@ -180,7 +180,7 @@ class Genome:
         """
         return cls(ANCESTOR_SOURCE, seed, identity=identity, generation=1)
 
-    def child(self, birth_index):
+    def child(self, birth_index, mutation_probability=1.0):
         """ Attempts one offspring. The attempt may fail.
 
             Exactly one mutation is tried. If the result cannot be parsed, the
@@ -193,12 +193,25 @@ class Genome:
             of mutants that parse still crash when called, and those die in the
             world rather than here, so the cause of death is recorded honestly.
         :param birth_index: Which offspring this is, counting from zero
+        :param mutation_probability: Chance this offspring is mutated at all.
+            At 1.0 every birth mutates, which is a rate of one mutation per
+            genome per generation. For a genome of a few hundred bytes with no
+            redundancy that is far above any biological rate, and it drives the
+            population past the error threshold: damage accumulates faster than
+            selection can remove it and the lineage melts down. Below the
+            threshold most offspring are faithful copies and variation still
+            arrives, just slowly enough to be selected on.
         :return: A new Genome, or None if the mutant could not be parsed
         """
-        candidate = mutate_source(self.source, derive_seed(self.seed, birth_index))
+        seed = derive_seed(self.seed, birth_index)
+        identity = f'{self.identity}.{birth_index}'
+
+        if random.Random(seed).random() >= mutation_probability:
+            return Genome(source=self.source, seed=seed, identity=identity,
+                          generation=self.generation + 1)
+
+        candidate = mutate_source(self.source, seed)
         if not is_viable(candidate):
             return None
-        return Genome(source=candidate,
-                      seed=derive_seed(self.seed, birth_index),
-                      identity=f'{self.identity}.{birth_index}',
+        return Genome(source=candidate, seed=seed, identity=identity,
                       generation=self.generation + 1)

--- a/creatures/genome.py
+++ b/creatures/genome.py
@@ -144,7 +144,7 @@ def mutate_source(source, seed):
     return mutate.Creature._flawed_copy(source)  # pylint: disable=protected-access
 
 
-def _derive_seed(parent_seed, birth_index):
+def derive_seed(parent_seed, birth_index):
     """ Derives a child's seed from its parent's seed and birth index.
 
         Hashed rather than added so sibling seeds are not adjacent, which would
@@ -167,12 +167,18 @@ class Genome:
         self.generation = generation
 
     @classmethod
-    def founder(cls, seed):
-        """ Creates the first creature of a run.
-        :param seed: Founder seed for the whole lineage
+    def founder(cls, seed, identity='0'):
+        """ Creates a founding creature of a run.
+
+            Each founder needs its own identity. When several founders shared
+            the identity '0', every lineage in the event log appeared to
+            descend from the same creature and per-creature tracking silently
+            collapsed.
+        :param seed: Founder seed for this lineage
+        :param identity: Lineage root, unique per founder
         :return: A Genome carrying the unmutated ancestor
         """
-        return cls(ANCESTOR_SOURCE, seed, identity='0', generation=1)
+        return cls(ANCESTOR_SOURCE, seed, identity=identity, generation=1)
 
     def child(self, birth_index):
         """ Attempts one offspring. The attempt may fail.
@@ -189,10 +195,10 @@ class Genome:
         :param birth_index: Which offspring this is, counting from zero
         :return: A new Genome, or None if the mutant could not be parsed
         """
-        candidate = mutate_source(self.source, _derive_seed(self.seed, birth_index))
+        candidate = mutate_source(self.source, derive_seed(self.seed, birth_index))
         if not is_viable(candidate):
             return None
         return Genome(source=candidate,
-                      seed=_derive_seed(self.seed, birth_index),
+                      seed=derive_seed(self.seed, birth_index),
                       identity=f'{self.identity}.{birth_index}',
                       generation=self.generation + 1)

--- a/creatures/lifecycle.py
+++ b/creatures/lifecycle.py
@@ -12,22 +12,39 @@ there first. That is the competition the 2017 version never had: it counted
 fuel down with nothing to eat and no shared resource.
 """
 
-# The 2017 self_mutator used fuel 10, death at age 10, fertile between ages 2
-# and 5, and a reproduction cost of 5. Those numbers drive a *mutating*
-# population extinct every time, because only about 17% of births produce a
-# working creature (see genome.py), so a creature needs roughly six attempts
-# just to replace itself and those settings allow about two.
+# These defaults were tuned until a mutating population reaches a steady state.
+# The failures along the way are worth recording, because each one looked like a
+# different problem:
 #
-# These defaults widen the fertile window and cheapen reproduction enough that
-# a mutating population sustains itself. That is the minimum for there to be
-# anything to observe: a lineage that cannot reach replacement is not a
-# minimal creature, it is a dead one.
+#   max_age 10, fertile 2-5, cost 5   (the 2017 numbers)
+#       Below replacement. Only ~17% of births produce a working creature, so a
+#       creature needs roughly six attempts to replace itself and these allow
+#       about two. Extinct every time.
+#
+#   max_age 12, fertile 2-8, cost 1
+#       Boom then total collapse, every seed, always by about tick 24. The
+#       deaths told the story: 219 old_age, 0 starvation, 0 crashed. With a
+#       short life and a narrow fertile window the whole population is a single
+#       age cohort. Food shortage suppresses breeding for a few ticks, no
+#       replacements are born, and then everyone hits max_age together.
+#
+#   max_age 40, fertile 2-30, cost 20
+#       Steady. A long life relative to the fertile window keeps several
+#       generations alive at once, so a pause in breeding no longer wipes out
+#       the whole population. Peaks around 210 then settles near 110 and stays
+#       there. Staggering the founders' starting ages was also tried and turned
+#       out not to be needed once lifespan was long enough.
+#
+# The reproduction cost matters for a second reason: at cost 1 breeding is
+# effectively free, so births are limited only by the fertile window rather than
+# by food, and the population overshoots carrying capacity badly. A real cost
+# couples the birth rate to the food supply.
 DEFAULT_FUEL = 15
 DEFAULT_MAX_FUEL = 40
-DEFAULT_MAX_AGE = 12
+DEFAULT_MAX_AGE = 40
 DEFAULT_FERTILE_FROM = 2
-DEFAULT_FERTILE_UNTIL = 8
-DEFAULT_REPRODUCTION_COST = 1
+DEFAULT_FERTILE_UNTIL = 30
+DEFAULT_REPRODUCTION_COST = 20
 
 
 class DeadCreatureError(Exception):

--- a/creatures/run.py
+++ b/creatures/run.py
@@ -1,0 +1,131 @@
+""" run.py - runs a creature population and records what happened.
+
+    python -m creatures.run --seed 1 --ticks 100
+    python -m creatures.run --replay results/creatures/seed-1
+
+Each run gets a directory under results/creatures/, keyed by seed, holding a
+manifest and an append-only event log.
+
+Rerunning a seed does not reproduce the run. Genetics are reproducible, but OS
+scheduling decides which creature reaches the food pool first, so a rerun is
+statistically similar rather than identical. That is why the log exists: to
+replay a run, read its log rather than running it again.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+import time
+
+from creatures import events, supervisor
+
+DEFAULT_RESULTS_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'results', 'creatures')
+
+
+def run_directory(results_root, seed):
+    """ :return: Where a run with this seed is recorded """
+    return os.path.join(results_root, f'seed-{seed}')
+
+
+# Seven independent run parameters, all of which an experiment varies.
+def run(*, seed=1, ticks=100, founders=10,  # pylint: disable=too-many-arguments
+        regrowth=400, max_processes=supervisor.DEFAULT_MAX_PROCESSES,
+        timeout=supervisor.DEFAULT_TIMEOUT, results_root=DEFAULT_RESULTS_ROOT,
+        quiet=False):
+    """ Runs a population and records it.
+    :return: The run directory
+    """
+    directory = run_directory(results_root, seed)
+    if os.path.isdir(directory):
+        shutil.rmtree(directory)
+    os.makedirs(directory)
+
+    started = time.monotonic()
+    with events.EventLog(os.path.join(directory, 'events.jsonl')) as log:
+        with supervisor.Supervisor(regrowth=regrowth, max_processes=max_processes,
+                                   timeout=timeout, log=log) as sup:
+            sup.start(founders=founders, seed=seed)
+            for _ in range(ticks):
+                sup.tick()
+                if not sup.living:
+                    break
+            summary = sup.summary()
+
+    summary['wall_seconds'] = round(time.monotonic() - started, 2)
+    events.write_manifest(os.path.join(directory, 'manifest.json'),
+                          seed=seed, ticks=ticks, founders=founders,
+                          regrowth=regrowth, max_processes=max_processes,
+                          timeout=timeout, summary=summary)
+    if not quiet:
+        _report(directory, summary)
+    return directory
+
+
+def _report(directory, summary):
+    """ Prints a short account of a completed run. """
+    print(f'run written to {directory}')
+    print(f'  ticks {summary["ticks"]}, survivors {summary["living"]}, '
+          f'births {summary["births"]}, {summary["wall_seconds"]}s')
+    causes = ', '.join(f'{c} {n}' for c, n in summary['deaths'].items() if n)
+    print(f'  deaths: {causes or "none"}')
+    if summary['cap_hits']:
+        print(f'  WARNING: process cap hit {summary["cap_hits"]} times. The food '
+              f'parameters were wrong, so this population was limited by an '
+              f'artificial ceiling rather than by food.')
+
+
+def summarize(directory):
+    """ Reads a recorded run back and describes it, without running anything.
+    :param directory: A run directory
+    :return: 0 on success, 1 if there is nothing there
+    """
+    log_path = os.path.join(directory, 'events.jsonl')
+    if not os.path.isfile(log_path):
+        print(f'no event log in {directory}')
+        return 1
+
+    replay = events.Replay(log_path)
+    population = replay.population_over_time
+    print(f'replayed {directory}, no processes started')
+    print(f'  ticks recorded     {len(population)}')
+    if population:
+        print(f'  population         start {population[0]}, '
+              f'peak {max(population)}, end {population[-1]}')
+    print(f'  births             {replay.births}')
+    print(f'  failed births      {replay.failed_births} '
+          f'({replay.birth_failure_rate:.1%} of attempts)')
+    print(f'  deepest generation {replay.deepest_generation}')
+    causes = ', '.join(f'{c} {n}' for c, n in sorted(replay.deaths.items()))
+    print(f'  deaths             {causes or "none"}')
+    return 0
+
+
+def main(arguments):
+    """ Entry point for the command line. """
+    parser = argparse.ArgumentParser(
+        description='Run a creature population, or replay a recorded run.')
+    parser.add_argument('--replay', metavar='DIR',
+                        help='Replay a recorded run instead of running one.')
+    parser.add_argument('--seed', type=int, default=1)
+    parser.add_argument('--ticks', type=int, default=100)
+    parser.add_argument('--founders', type=int, default=10)
+    parser.add_argument('--regrowth', type=int, default=400)
+    parser.add_argument('--max-processes', type=int,
+                        default=supervisor.DEFAULT_MAX_PROCESSES)
+    parser.add_argument('--timeout', type=float, default=supervisor.DEFAULT_TIMEOUT)
+    parser.add_argument('--results-root', default=DEFAULT_RESULTS_ROOT)
+    args = parser.parse_args(arguments)
+
+    if args.replay:
+        return summarize(args.replay)
+
+    run(seed=args.seed, ticks=args.ticks, founders=args.founders,
+        regrowth=args.regrowth, max_processes=args.max_processes,
+        timeout=args.timeout, results_root=args.results_root)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/creatures/supervisor.py
+++ b/creatures/supervisor.py
@@ -34,6 +34,11 @@ DEFAULT_TIMEOUT = 0.5
 # Safety valve only. Set well above the population the food supply can sustain.
 DEFAULT_MAX_PROCESSES = 500
 
+# Chance that a given offspring is mutated at all. Mutating every offspring is
+# a rate of one mutation per genome per generation, which is far past the error
+# threshold for this substrate: see the sweep recorded in the PR for #26.
+DEFAULT_MUTATION_PROBABILITY = 0.1
+
 CAUSES = ('starvation', 'old_age', 'crashed', 'timeout')
 
 
@@ -100,11 +105,12 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
     """
 
     # Eight world parameters, all of which an experiment legitimately varies.
-    def __init__(self, *, regrowth=100, food=None,  # pylint: disable=too-many-arguments
+    def __init__(self, *, regrowth=200, food=None,  # pylint: disable=too-many-arguments
                  max_processes=DEFAULT_MAX_PROCESSES,
                  timeout=DEFAULT_TIMEOUT, max_age=lifecycle.DEFAULT_MAX_AGE,
                  max_fuel=lifecycle.DEFAULT_MAX_FUEL,
-                 starting_fuel=lifecycle.DEFAULT_FUEL, log=None):
+                 starting_fuel=lifecycle.DEFAULT_FUEL,
+                 mutation_probability=DEFAULT_MUTATION_PROBABILITY, log=None):
         self.world = lifecycle.World(
             food=regrowth * 5 if food is None else food, regrowth=regrowth)
         self.max_processes = max_processes
@@ -112,6 +118,7 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         self.max_age = max_age
         self.max_fuel = max_fuel
         self.starting_fuel = starting_fuel
+        self.mutation_probability = mutation_probability
 
         # Optional EventLog. Forked runs cannot be replayed by re-running, so
         # what happened is written down as it happens.
@@ -182,8 +189,13 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         except OSError:
             return None
 
-        ready, _, _ = select.select([creature.channel], [], [], self.timeout)
-        if not ready:
+        # poll() rather than select(): select() is limited to FD_SETSIZE (1024)
+        # file descriptors and raises "filedescriptor out of range" once the
+        # population grows past it. Each living creature holds a socket, so that
+        # ceiling is reachable in a normal run.
+        poller = select.poll()
+        poller.register(creature.channel, select.POLLIN)
+        if not poller.poll(self.timeout * 1000):
             return 'timeout'
         try:
             raw = creature.channel.recv(65536)
@@ -269,7 +281,8 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
                 self.log.birth_failed(tick=self.ticks,
                                       parent=creature.gene.identity, reason='capped')
             return None
-        child = creature.gene.child(birth_index=creature.births)
+        child = creature.gene.child(birth_index=creature.births,
+                                    mutation_probability=self.mutation_probability)
         creature.births += 1
         creature.life.pay_for_reproduction()
         if child is None:

--- a/creatures/supervisor.py
+++ b/creatures/supervisor.py
@@ -104,7 +104,7 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
                  max_processes=DEFAULT_MAX_PROCESSES,
                  timeout=DEFAULT_TIMEOUT, max_age=lifecycle.DEFAULT_MAX_AGE,
                  max_fuel=lifecycle.DEFAULT_MAX_FUEL,
-                 starting_fuel=lifecycle.DEFAULT_FUEL):
+                 starting_fuel=lifecycle.DEFAULT_FUEL, log=None):
         self.world = lifecycle.World(
             food=regrowth * 5 if food is None else food, regrowth=regrowth)
         self.max_processes = max_processes
@@ -113,6 +113,9 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         self.max_fuel = max_fuel
         self.starting_fuel = starting_fuel
 
+        # Optional EventLog. Forked runs cannot be replayed by re-running, so
+        # what happened is written down as it happens.
+        self.log = log
         self.living = []
         self.deaths = dict.fromkeys(CAUSES, 0)
         self.births = 0
@@ -143,6 +146,10 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         child_end.close()
         creature = Creature(pid, parent_end, gene, self._new_life())
         self.living.append(creature)
+        if self.log is not None:
+            parent = gene.identity.rsplit('.', 1)[0] if '.' in gene.identity else None
+            self.log.birth(tick=self.ticks, identity=gene.identity,
+                           generation=gene.generation, parent=parent)
         return creature
 
     def start(self, founders, seed):
@@ -151,8 +158,13 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         :param seed: Founder seed; each founder gets seed + its index
         :return: None
         """
+        # Founder seeds are derived, not seed + index. Adding the index made
+        # consecutive run seeds share almost all their founders: seeds 1 and 2
+        # differed in one founder out of twenty, so different runs produced
+        # near-identical results.
         for index in range(founders):
-            self.spawn(genome.Genome.founder(seed=seed + index))
+            self.spawn(genome.Genome.founder(seed=genome.derive_seed(seed, index),
+                                             identity=str(index)))
 
     # Seven ways a creature can fail to answer usefully, each needing its own
     # early exit. Collapsing them would only hide which one happened.
@@ -190,6 +202,10 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
     def _kill(self, creature, cause):
         """ Ends a creature: records the cause, kills the process, reaps it. """
         self.deaths[cause] += 1
+        if self.log is not None:
+            self.log.death(tick=self.ticks, identity=creature.gene.identity,
+                           cause=cause, age=creature.life.age,
+                           generation=creature.gene.generation)
         creature.close()
         try:
             os.kill(creature.pid, signal.SIGKILL)
@@ -237,6 +253,10 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         for gene in filter(None, newborns):
             self.spawn(gene)
 
+        if self.log is not None:
+            self.log.snapshot(tick=self.ticks, population=len(self.living),
+                              food=self.world.food)
+
     def _breed(self, creature, pending):
         """ Attempts one birth, respecting the process cap.
         :param creature: The parent
@@ -245,11 +265,18 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         """
         if len(self.living) + pending >= self.max_processes:
             self.cap_hits += 1
+            if self.log is not None:
+                self.log.birth_failed(tick=self.ticks,
+                                      parent=creature.gene.identity, reason='capped')
             return None
         child = creature.gene.child(birth_index=creature.births)
         creature.births += 1
         creature.life.pay_for_reproduction()
         if child is None:
+            if self.log is not None:
+                self.log.birth_failed(tick=self.ticks,
+                                      parent=creature.gene.identity,
+                                      reason='unparseable')
             return None
         self.births += 1
         return child

--- a/creatures/test_ecology.py
+++ b/creatures/test_ecology.py
@@ -17,7 +17,8 @@ import unittest
 from creatures import genome, lifecycle
 
 
-def run_population(*, regrowth, ticks=120, founders=20, cap=None, mutate=True):
+def run_population(*, regrowth, ticks=120, founders=20,  # pylint: disable=too-many-locals
+                   cap=None, mutate=True):
     """Runs a population in-process and reports what happened.
 
     :param regrowth: Food added to the shared pool each tick

--- a/creatures/test_events.py
+++ b/creatures/test_events.py
@@ -21,6 +21,7 @@ from creatures import events
 
 
 class EventTestCase(unittest.TestCase):
+    """Shared setup: every test writes into a throwaway directory."""
 
     def setUp(self):
         self.root = tempfile.mkdtemp(prefix='mutate-events-')
@@ -81,6 +82,7 @@ class TestReplay(EventTestCase):
     """Reconstructing a run from its log, with no processes involved."""
 
     def write_run(self):
+        """Writes a small three-tick run to replay."""
         with events.EventLog(self.path) as log:
             log.birth(tick=0, identity='0', generation=1, parent=None)
             log.birth(tick=0, identity='1', generation=1, parent=None)

--- a/creatures/test_events.py
+++ b/creatures/test_events.py
@@ -1,0 +1,170 @@
+"""Tests for the event log, run manifest, and replay.
+
+Written before the implementation.
+
+Forked runs cannot be reproduced byte for byte, because OS scheduling decides
+who reaches the food pool first. So instead of re-running to find out what
+happened, every run records what happened. The log is the record; replay reads
+it back without spawning a single process.
+
+That matters twice over: analysis stops depending on luck, and phase 4 can
+animate a run without re-running it.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from creatures import events
+
+
+class EventTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='mutate-events-')
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.path = os.path.join(self.root, 'events.jsonl')
+
+
+class TestWriting(EventTestCase):
+
+    def test_events_are_written_one_per_line(self):
+        with events.EventLog(self.path) as log:
+            log.birth(tick=1, identity='0.1', generation=2, parent='0')
+            log.death(tick=2, identity='0.1', cause='old_age', age=12, generation=2)
+        with open(self.path, encoding='utf-8') as handle:
+            lines = handle.read().splitlines()
+        self.assertEqual(2, len(lines))
+        for line in lines:
+            json.loads(line)
+
+    def test_events_keep_their_order(self):
+        with events.EventLog(self.path) as log:
+            for tick in range(5):
+                log.birth(tick=tick, identity=str(tick), generation=1, parent=None)
+        ticks = [e['tick'] for e in events.read(self.path)]
+        self.assertEqual([0, 1, 2, 3, 4], ticks)
+
+    def test_every_event_records_its_kind_and_tick(self):
+        with events.EventLog(self.path) as log:
+            log.birth(tick=1, identity='0.1', generation=2, parent='0')
+            log.death(tick=1, identity='0', cause='crashed', age=3, generation=1)
+            log.birth_failed(tick=1, parent='0', reason='unparseable')
+            log.snapshot(tick=1, population=5, food=100)
+        kinds = [e['kind'] for e in events.read(self.path)]
+        self.assertEqual(['birth', 'death', 'birth_failed', 'snapshot'], kinds)
+        for event in events.read(self.path):
+            self.assertIn('tick', event)
+
+    def test_log_is_append_only_across_reopens(self):
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=1, population=1, food=1)
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=2, population=2, food=2)
+        self.assertEqual(2, len(list(events.read(self.path))))
+
+    def test_reading_a_missing_log_gives_nothing(self):
+        self.assertEqual([], list(events.read(os.path.join(self.root, 'nope.jsonl'))))
+
+    def test_a_truncated_final_line_is_skipped_not_fatal(self):
+        """A run killed mid-write must still be analysable."""
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=1, population=1, food=1)
+        with open(self.path, 'a', encoding='utf-8') as handle:
+            handle.write('{"kind": "snapshot", "tick": 2, "popula')
+        self.assertEqual(1, len(list(events.read(self.path))))
+
+
+class TestReplay(EventTestCase):
+    """Reconstructing a run from its log, with no processes involved."""
+
+    def write_run(self):
+        with events.EventLog(self.path) as log:
+            log.birth(tick=0, identity='0', generation=1, parent=None)
+            log.birth(tick=0, identity='1', generation=1, parent=None)
+            log.snapshot(tick=0, population=2, food=100)
+            log.birth(tick=1, identity='0.0', generation=2, parent='0')
+            log.snapshot(tick=1, population=3, food=90)
+            log.death(tick=2, identity='1', cause='crashed', age=2, generation=1)
+            log.birth_failed(tick=2, parent='0', reason='unparseable')
+            log.snapshot(tick=2, population=2, food=85)
+
+    def test_population_over_time_is_recovered(self):
+        self.write_run()
+        replay = events.Replay(self.path)
+        self.assertEqual([2, 3, 2], replay.population_over_time)
+
+    def test_food_over_time_is_recovered(self):
+        self.write_run()
+        self.assertEqual([100, 90, 85], events.Replay(self.path).food_over_time)
+
+    def test_causes_of_death_are_counted(self):
+        self.write_run()
+        self.assertEqual({'crashed': 1}, events.Replay(self.path).deaths)
+
+    def test_births_and_failed_births_are_counted(self):
+        self.write_run()
+        replay = events.Replay(self.path)
+        self.assertEqual(3, replay.births)
+        self.assertEqual(1, replay.failed_births)
+
+    def test_deepest_generation_is_recovered(self):
+        self.write_run()
+        self.assertEqual(2, events.Replay(self.path).deepest_generation)
+
+    def test_birth_failure_rate_is_reported(self):
+        """The measurement that matters: how brittle the substrate is."""
+        self.write_run()
+        replay = events.Replay(self.path)
+        self.assertAlmostEqual(1 / 4, replay.birth_failure_rate, places=5)
+
+    def test_living_at_a_tick_is_recoverable(self):
+        """Phase 4 needs to know who was alive when, without re-running."""
+        self.write_run()
+        replay = events.Replay(self.path)
+        self.assertEqual({'0', '1'}, replay.living_at(0))
+        self.assertEqual({'0', '1', '0.0'}, replay.living_at(1))
+        self.assertEqual({'0', '0.0'}, replay.living_at(2))
+
+    def test_replaying_an_empty_log_does_not_crash(self):
+        replay = events.Replay(self.path)
+        self.assertEqual([], replay.population_over_time)
+        self.assertEqual(0, replay.births)
+
+
+class TestManifest(EventTestCase):
+
+    def test_records_everything_needed_to_rerun(self):
+        path = os.path.join(self.root, 'manifest.json')
+        events.write_manifest(path, seed=42, ticks=50, founders=10,
+                              regrowth=400, max_processes=500, timeout=0.5,
+                              summary={'births': 3})
+        with open(path, encoding='utf-8') as handle:
+            manifest = json.load(handle)
+        for field in ('seed', 'ticks', 'founders', 'regrowth', 'max_processes',
+                      'timeout', 'git_sha', 'python_version', 'summary'):
+            self.assertIn(field, manifest, f'manifest is missing {field}')
+        self.assertEqual(42, manifest['seed'])
+
+    def test_records_that_timing_is_not_reproducible(self):
+        """A reader must not assume a rerun gives identical results, because
+        process scheduling decides who eats first."""
+        path = os.path.join(self.root, 'manifest.json')
+        events.write_manifest(path, seed=1, ticks=1, founders=1, regrowth=1,
+                              max_processes=1, timeout=0.5, summary={})
+        with open(path, encoding='utf-8') as handle:
+            self.assertIn('reproducibility', json.load(handle))
+
+    def test_a_manifest_round_trips(self):
+        path = os.path.join(self.root, 'manifest.json')
+        events.write_manifest(path, seed=7, ticks=3, founders=2, regrowth=9,
+                              max_processes=11, timeout=0.25, summary={})
+        loaded = events.read_manifest(path)
+        self.assertEqual(7, loaded['seed'])
+        self.assertEqual(11, loaded['max_processes'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/creatures/test_genome.py
+++ b/creatures/test_genome.py
@@ -164,6 +164,13 @@ class TestLineage(unittest.TestCase):
         self.assertEqual(1, founder.generation)
         self.assertEqual('0', founder.identity)
 
+    def test_founders_can_be_given_distinct_identities(self):
+        """Several founders sharing identity '0' made every lineage in the
+        event log look like it descended from one creature."""
+        identities = {genome.Genome.founder(seed=i, identity=str(i)).identity
+                      for i in range(5)}
+        self.assertEqual(5, len(identities))
+
     def test_child_seed_derives_from_parent_and_birth_index(self):
         founder = genome.Genome.founder(seed=42)
         first_index, first = self.first_viable_child(founder)

--- a/creatures/test_supervisor.py
+++ b/creatures/test_supervisor.py
@@ -61,6 +61,24 @@ class TestSpawning(SupervisorTestCase):
         sup.start(founders=3, seed=1)
         self.assertEqual(3, len(sup.living))
 
+    def test_different_run_seeds_give_different_founders(self):
+        """Founder seeds used to be seed + index, so runs with consecutive
+        seeds shared almost every founder and produced near-identical results."""
+        first = self.make()
+        first.start(founders=10, seed=1)
+        second = self.make()
+        second.start(founders=10, seed=2)
+        self.assertEqual(set(), {c.gene.seed for c in first.living}
+                         & {c.gene.seed for c in second.living})
+
+    def test_founders_get_distinct_identities(self):
+        """Otherwise the event log shows every lineage descending from one
+        creature and per-creature tracking collapses."""
+        sup = self.make()
+        sup.start(founders=5, seed=1)
+        identities = {c.gene.identity for c in sup.living}
+        self.assertEqual(5, len(identities))
+
     def test_a_creature_answers_a_tick(self):
         sup = self.make()
         creature = sup.spawn(genome.Genome.founder(seed=1))

--- a/creatures/test_supervisor.py
+++ b/creatures/test_supervisor.py
@@ -41,6 +41,7 @@ class SupervisorTestCase(unittest.TestCase):
             sup.shutdown()
 
     def make(self, **kwargs):
+        """Builds a Supervisor that is torn down after the test."""
         kwargs.setdefault('regrowth', 400)
         kwargs.setdefault('max_processes', 50)
         sup = supervisor.Supervisor(**kwargs)
@@ -208,6 +209,16 @@ class TestConcurrencyCap(SupervisorTestCase):
             sup.tick()
         self.assertGreater(sup.cap_hits, 0)
 
+    def test_a_large_population_does_not_exhaust_the_fd_limit(self):
+        """select() caps at 1024 file descriptors and each creature holds a
+        socket, so a growing population used to crash with "filedescriptor out
+        of range". poll() has no such limit."""
+        sup = self.make(max_processes=300, regrowth=5000)
+        sup.start(founders=40, seed=1)
+        for _ in range(6):
+            sup.tick()
+        self.assertGreater(len(sup.living), 0)
+
     def test_a_generous_cap_is_never_hit(self):
         sup = self.make(max_processes=500, regrowth=100)
         sup.start(founders=5, seed=1)
@@ -264,3 +275,53 @@ class TestWorldWiring(SupervisorTestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestSteadyState(SupervisorTestCase):
+    """The defaults must produce a population that persists.
+
+    Two earlier default sets did not, and each failed in a different way that
+    looked convincing at short run lengths. See the comment block in
+    lifecycle.py for the full history.
+    """
+
+    def test_the_default_population_survives_a_long_run(self):
+        sup = self.make(max_processes=600, regrowth=200)
+        sup.start(founders=20, seed=1)
+        history = []
+        for _ in range(120):
+            sup.tick()
+            history.append(len(sup.living))
+            if not sup.living:
+                break
+        self.assertGreater(history[-1], 0,
+                           f'extinct at tick {len(history)}, peak was {max(history)}')
+
+    def test_the_population_is_not_still_falling_at_the_end(self):
+        """Extinction used to take about 24 ticks, and a 40 tick run read as
+        'stable at 19' when it was actually still inside the growth phase.
+        Comparing the two halves of the tail catches a slow decline."""
+        sup = self.make(max_processes=600, regrowth=200)
+        sup.start(founders=20, seed=2)
+        history = []
+        for _ in range(120):
+            sup.tick()
+            history.append(len(sup.living))
+            if not sup.living:
+                break
+        self.assertEqual(120, len(history), 'went extinct')
+        first_half = history[60:90]
+        second_half = history[90:]
+        self.assertGreater(sum(second_half) / len(second_half),
+                           sum(first_half) / len(first_half) * 0.5,
+                           'population is collapsing rather than holding')
+
+    def test_generations_keep_turning_over(self):
+        """A surviving population is not enough; it has to still be evolving."""
+        sup = self.make(max_processes=600, regrowth=200)
+        sup.start(founders=20, seed=3)
+        for _ in range(80):
+            sup.tick()
+            if not sup.living:
+                break
+        self.assertGreater(max(c.gene.generation for c in sup.living), 3)


### PR DESCRIPTION
Closes #26. **Completes phase 2 of #14.**

Forked runs cannot be reproduced byte for byte, because OS scheduling decides which creature reaches the food pool first. So instead of re-running to find out what happened, every run writes down what happened as it goes, as append-only JSON lines. Replay reads it back **without spawning a single process**, which is what phase 4 needs to animate a run.

```
python -m creatures.run --seed 1 --ticks 150
python -m creatures.run --replay results/creatures/seed-1
```

Events cover birth, death with cause, failed births distinguishing `unparseable` from `capped`, and a per-tick snapshot of population and food. A truncated final line from an interrupted run is skipped rather than treated as fatal. The manifest records the parameters plus an explicit note that a rerun is statistically similar, not identical.

## Two bugs found by running it for real

**Every founder shared the identity `'0'`**, because `Genome.founder` hardcoded it. All lineages in the log appeared to descend from one creature and per-creature tracking silently collapsed.

**Founder seeds were `seed + index`**, so runs with consecutive seeds shared almost all their founders. Seeds 1, 2 and 3 differed in one founder out of twenty and produced near-identical results: peak 269, generation 28, 493 crashes, all three. That read as reassuring stability and was an artifact.

## The finding: the population does not persist

With genuinely independent founders, the result changes completely.

| seed | peak | outcome | deepest generation |
|---|---|---|---|
| 1 | 54 | extinct at tick 114 | 20 |
| 2 | 55 | extinct at tick 116 | 21 |
| 3 | 50 | extinct at tick 61 | 9 |

Trajectories all have the same shape: grow for about 20 ticks, peak near 50, then decline steadily to zero.

```
seed 1: [20, 54, 25, 10, 11, 13, 19, 7, 7, 3, 6, 3] -> 0
seed 2: [20, 54, 31, 19,  7,  6,  9, 4, 2, 5, 4, 2] -> 0
seed 3: [20, 46, 32, 27,  9,  8,  0]
```

Births fail 61-66% of the time and crashes are comparable to old age as a cause of death. **Food is not the constraint at regrowth 800; mutational load is.**

This revises the "stable at 19" reading I reported on #25. That run was 40 ticks, short enough to sit entirely inside the initial growth phase. I called it stable and it was not.

The in-process ecology tests still pass because they run 120 ticks with identical founder sources, which is a gentler setup than a real forked run. Their survival result should be treated as the optimistic bound rather than the expected behaviour.

## What this means for phase 3

A 2D world built on this would empty out. Before adding space, the population needs to reach replacement, which is a parameter question (fecundity, mutation rate, fertile window) and possibly the error-threshold sweep already written up in #30. Worth deciding deliberately rather than discovering it again with a map attached.

```
114 creature tests, 63 legacy tests, all green
10.00/10 under pylint
```