### PR TITLE
Widen the creature decision space and measure whether it evolves

### DIFF
--- a/creatures/events.py
+++ b/creatures/events.py
@@ -71,9 +71,15 @@ class EventLog:
         """
         self._write('birth_failed', tick, parent=parent, reason=reason)
 
-    def snapshot(self, *, tick, population, food):
-        """ Records aggregate world state at the end of a tick. """
-        self._write('snapshot', tick, population=population, food=food)
+    def snapshot(self, *, tick, population, food, strategy=None):
+        """ Records aggregate world state at the end of a tick.
+        :param strategy: Optional dict of the living population's mean realised
+            decision (mean_eat, breed_rate, mean_endowment), or None when nobody
+            is alive to have a strategy. This is how we tell a population that
+            evolves from one that merely persists.
+        """
+        self._write('snapshot', tick, population=population, food=food,
+                    strategy=strategy)
 
 
 def read(path):
@@ -112,6 +118,29 @@ class Replay:
     def food_over_time(self):
         """ :return: Food in the pool at the end of each tick """
         return [e['food'] for e in self.events if e['kind'] == 'snapshot']
+
+    @property
+    def strategy_over_time(self):
+        """ The living population's mean realised strategy at each tick that had
+            one. Skips ticks where nobody was alive.
+        :return: List of strategy dicts in tick order
+        """
+        return [e['strategy'] for e in self.events
+                if e['kind'] == 'snapshot' and e.get('strategy') is not None]
+
+    @property
+    def strategy_drift(self):
+        """ How far the population's strategy moved from its first recorded value
+            to its last. A population that only persists shows near-zero drift; a
+            population that evolves shows the strategy shifting.
+        :return: Per-field change (last minus first), or an empty dict if there
+            is not enough data
+        """
+        history = self.strategy_over_time
+        if len(history) < 2:
+            return {}
+        first, last = history[0], history[-1]
+        return {key: last[key] - first[key] for key in first if key in last}
 
     @property
     def births(self):

--- a/creatures/genome.py
+++ b/creatures/genome.py
@@ -27,19 +27,29 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 
 import mutate  # noqa: E402  pylint: disable=wrong-import-position
 
-# Deliberately minimal: eat harder when low, otherwise eat modestly and try to
-# breed. Anything cleverer would hand the process a strategy it is supposed to
-# find for itself.
+# Deliberately minimal, but it now perceives the world and makes a life-history
+# choice, so mutation has a real strategy landscape to explore rather than four
+# lines to break.
 #
-# Note what it does NOT do: it never checks whether it is old enough to breed.
-# An earlier version hardcoded `2 <= age <= 5`, which quietly capped every
-# creature at two breeding attempts regardless of the engine's fertile window,
-# and drove every population to extinction. Fertility is the engine's business
-# (see lifecycle.can_reproduce); the creature just asks.
-ANCESTOR_SOURCE = '''def act(age, fuel, max_fuel):
-    if fuel < max_fuel / 2:
-        return {'eat': 5, 'reproduce': False}
-    return {'eat': 3, 'reproduce': True}
+# It senses two things beyond its own state: how much food is in the shared pool
+# and how many creatures are alive. It makes three choices: how much to eat,
+# whether to try to breed, and how much of its own fuel to endow each offspring.
+# The endowment is the evolvable r/K dial: many cheap offspring that start poor,
+# or few well-provisioned ones.
+#
+# What it still does NOT do is police its own fertility. An earlier version
+# hardcoded `2 <= age <= 5`, which capped every creature at two breeding
+# attempts regardless of the engine's fertile window and drove every population
+# extinct. Fertility is the engine's business (lifecycle.can_reproduce); the
+# creature just asks.
+ANCESTOR_SOURCE = '''def act(age, fuel, max_fuel, food_available, population):
+    hungry = fuel < max_fuel / 2
+    scarce = food_available < population
+    return {
+        'eat': 6 if (hungry or scarce) else 3,
+        'reproduce': not hungry,
+        'endowment': fuel // 4,
+    }
 '''
 
 class MisbehavingCreatureError(Exception):
@@ -88,38 +98,44 @@ def load(source):
     return act
 
 
-def decide(source, *, age, fuel, max_fuel):
+# Five sense inputs a creature conditions on, all keyword-only. The count
+# reflects how much of the world a creature can perceive, not a design problem.
+def decide(source, *, age, fuel, max_fuel,  # pylint: disable=too-many-arguments
+           food_available, population):
     """ Asks a creature what it wants to do, and never trusts the answer.
 
-        A mutant can return anything at all, so the result is normalised:
-        missing keys take defaults, the food request is clamped into range, and
-        anything non-numeric becomes zero. A creature that raises, returns a
-        non-dict, or has the wrong signature is reported as misbehaving rather
-        than allowed to corrupt the world.
+        A mutant can return anything at all, so the result is normalised: missing
+        keys take defaults, and every numeric field is clamped into range with
+        anything non-numeric becoming zero. A creature that raises, returns a
+        non-dict, or no longer accepts the full call is reported as misbehaving
+        rather than allowed to corrupt the world.
     :param source: Creature source
     :param age: Current age in ticks
     :param fuel: Current fuel
     :param max_fuel: The creature's fuel ceiling
-    :return: dict with 'eat' (int) and 'reproduce' (bool)
+    :param food_available: Food in the shared pool this tick
+    :param population: How many creatures are alive
+    :return: dict with 'eat' (int), 'reproduce' (bool), 'endowment' (int)
     """
     act = load(source)
     try:
-        raw = act(age, fuel, max_fuel)
+        raw = act(age, fuel, max_fuel, food_available, population)
     except Exception as error:  # pylint: disable=broad-except
         raise MisbehavingCreatureError(f'act() raised: {error}') from error
 
     if not isinstance(raw, dict):
         raise MisbehavingCreatureError(f'act() returned {type(raw).__name__}, expected dict')
 
-    return {'eat': _clamp_eat(raw.get('eat', 0), max_fuel),
-            'reproduce': bool(raw.get('reproduce', False))}
+    return {'eat': _clamp(raw.get('eat', 0), max_fuel),
+            'reproduce': bool(raw.get('reproduce', False)),
+            'endowment': _clamp(raw.get('endowment', 0), max_fuel)}
 
 
-def _clamp_eat(value, max_fuel):
-    """ Forces a food request into a sane range.
+def _clamp(value, ceiling):
+    """ Forces a numeric decision field into [0, ceiling].
     :param value: Whatever the creature asked for
-    :param max_fuel: Upper bound on a single request
-    :return: An integer between 0 and max_fuel
+    :param ceiling: Upper bound
+    :return: An integer between 0 and ceiling
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return 0
@@ -127,7 +143,7 @@ def _clamp_eat(value, max_fuel):
         wanted = int(value)
     except (ValueError, OverflowError):
         return 0
-    return max(0, min(wanted, max_fuel))
+    return max(0, min(wanted, ceiling))
 
 
 def mutate_source(source, seed):
@@ -189,8 +205,8 @@ class Genome:
             of the substrate, which is the quantity this project exists to
             measure, and no organism gets unlimited attempts at one birth.
 
-            Passing the parse gate is not the same as being alive. Roughly half
-            of mutants that parse still crash when called, and those die in the
+            Passing the parse gate is not the same as being alive. About 69% of
+            mutants that parse still crash when called, and those die in the
             world rather than here, so the cause of death is recorded honestly.
         :param birth_index: Which offspring this is, counting from zero
         :param mutation_probability: Chance this offspring is mutated at all.
@@ -206,11 +222,19 @@ class Genome:
         seed = derive_seed(self.seed, birth_index)
         identity = f'{self.identity}.{birth_index}'
 
+        # The mutate-or-not coin and the mutation itself must use independent
+        # seeds. Reusing one seed for both correlates them: when the coin only
+        # fires for seeds whose first random() is below the probability, and the
+        # mutation then reseeds with that same value, _flawed_copy's first draw
+        # is forced into the same low range and always selects the first
+        # operator (prepend). At mutation_probability 0.1 that made 97% of
+        # mutants unparseable, since prepending to `def act(...)` breaks the
+        # parse almost every time.
         if random.Random(seed).random() >= mutation_probability:
             return Genome(source=self.source, seed=seed, identity=identity,
                           generation=self.generation + 1)
 
-        candidate = mutate_source(self.source, seed)
+        candidate = mutate_source(self.source, derive_seed(seed, 'mutation'))
         if not is_viable(candidate):
             return None
         return Genome(source=candidate, seed=seed, identity=identity,

--- a/creatures/lifecycle.py
+++ b/creatures/lifecycle.py
@@ -29,22 +29,36 @@ fuel down with nothing to eat and no shared resource.
 #       replacements are born, and then everyone hits max_age together.
 #
 #   max_age 40, fertile 2-30, cost 20
-#       Steady. A long life relative to the fertile window keeps several
-#       generations alive at once, so a pause in breeding no longer wipes out
-#       the whole population. Peaks around 210 then settles near 110 and stays
-#       there. Staggering the founders' starting ages was also tried and turned
-#       out not to be needed once lifespan was long enough.
+#       Steady, before offspring endowment existed. A long life relative to the
+#       fertile window keeps several generations alive at once, so a pause in
+#       breeding no longer wipes out the whole population. Staggering the
+#       founders' starting ages was also tried and turned out not to be needed
+#       once lifespan was long enough.
 #
-# The reproduction cost matters for a second reason: at cost 1 breeding is
-# effectively free, so births are limited only by the fertile window rather than
-# by food, and the population overshoots carrying capacity badly. A real cost
-# couples the birth rate to the food supply.
+#   max_age 40, fertile 2-30, cost 20, WITH endowment
+#       Collapsed back to the founder count. Once a parent also transfers an
+#       endowment to each child (genome.py), a flat cost of 20 plus the
+#       endowment drains the parent to zero on the tick it breeds, and it
+#       starves. The flat cost was tuned for a model where reproduction had no
+#       other cost; endowment made it double-charging.
+#
+#   max_age 40, fertile 2-30, cost 2, WITH endowment
+#       Steady again. The endowment is now the real cost of reproduction, fuel
+#       transferred to the child rather than lost, so the flat cost drops to a
+#       small metabolic overhead. Peaks around 285, settles near 113, with all
+#       three death causes present (starvation, old age, and mutation crashes),
+#       which means food limitation, demography, and mutational load are all
+#       active at once.
+#
+# The flat cost still matters for a second reason even when small: it gates
+# fertility (can_reproduce needs fuel above it), so a starving creature cannot
+# breed, which is what couples the birth rate to the food supply.
 DEFAULT_FUEL = 15
 DEFAULT_MAX_FUEL = 40
 DEFAULT_MAX_AGE = 40
 DEFAULT_FERTILE_FROM = 2
 DEFAULT_FERTILE_UNTIL = 30
-DEFAULT_REPRODUCTION_COST = 20
+DEFAULT_REPRODUCTION_COST = 2
 
 
 class DeadCreatureError(Exception):

--- a/creatures/run.py
+++ b/creatures/run.py
@@ -99,6 +99,18 @@ def summarize(directory):
     print(f'  deepest generation {replay.deepest_generation}')
     causes = ', '.join(f'{c} {n}' for c, n in sorted(replay.deaths.items()))
     print(f'  deaths             {causes or "none"}')
+
+    strategy = replay.strategy_over_time
+    if strategy:
+        final = strategy[-1]
+        print(f'  genetic divergence {final.get("genetic_divergence", 0):.1%} '
+              f'of the living population is no longer the ancestor')
+        drift = replay.strategy_drift
+        if drift:
+            moved = ', '.join(f'{k} {v:+.2f}' for k, v in sorted(drift.items()))
+            print(f'  strategy drift     {moved}')
+            print('  (realised-strategy drift mixes genetic change with the age '
+                  'distribution;\n   genetic divergence is the cleaner evolution signal)')
     return 0
 
 

--- a/creatures/supervisor.py
+++ b/creatures/supervisor.py
@@ -86,7 +86,9 @@ def _child_loop(channel, source):
                 reply = genome.decide(source,
                                       age=request['age'],
                                       fuel=request['fuel'],
-                                      max_fuel=request['max_fuel'])
+                                      max_fuel=request['max_fuel'],
+                                      food_available=request['food_available'],
+                                      population=request['population'])
             except genome.MisbehavingCreatureError as error:
                 reply = {'error': str(error)}
             writer.write(json.dumps(reply) + '\n')
@@ -104,12 +106,13 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         world parameters, the population, and four separate tallies.
     """
 
-    # Eight world parameters, all of which an experiment legitimately varies.
+    # Nine world parameters, all of which an experiment legitimately varies.
     def __init__(self, *, regrowth=200, food=None,  # pylint: disable=too-many-arguments
                  max_processes=DEFAULT_MAX_PROCESSES,
                  timeout=DEFAULT_TIMEOUT, max_age=lifecycle.DEFAULT_MAX_AGE,
                  max_fuel=lifecycle.DEFAULT_MAX_FUEL,
                  starting_fuel=lifecycle.DEFAULT_FUEL,
+                 reproduction_cost=lifecycle.DEFAULT_REPRODUCTION_COST,
                  mutation_probability=DEFAULT_MUTATION_PROBABILITY, log=None):
         self.world = lifecycle.World(
             food=regrowth * 5 if food is None else food, regrowth=regrowth)
@@ -118,6 +121,7 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         self.max_age = max_age
         self.max_fuel = max_fuel
         self.starting_fuel = starting_fuel
+        self.reproduction_cost = reproduction_cost
         self.mutation_probability = mutation_probability
 
         # Optional EventLog. Forked runs cannot be replayed by re-running, so
@@ -136,13 +140,18 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         self.shutdown()
         return False
 
-    def _new_life(self):
-        return lifecycle.Lifecycle(fuel=self.starting_fuel, max_fuel=self.max_fuel,
-                                   max_age=self.max_age)
+    def _new_life(self, starting_fuel=None):
+        return lifecycle.Lifecycle(
+            fuel=self.starting_fuel if starting_fuel is None else starting_fuel,
+            max_fuel=self.max_fuel, max_age=self.max_age,
+            reproduction_cost=self.reproduction_cost)
 
-    def spawn(self, gene):
+    def spawn(self, gene, starting_fuel=None):
         """ Forks a new creature process.
         :param gene: The Genome the creature will run
+        :param starting_fuel: Fuel the creature begins with. None means the
+            world default; a newborn instead starts with what its parent endowed
+            it, which can be nothing.
         :return: The Creature, already added to the living population
         """
         parent_end, child_end = socket.socketpair()
@@ -151,7 +160,7 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
             parent_end.close()
             _child_loop(child_end, gene.source)
         child_end.close()
-        creature = Creature(pid, parent_end, gene, self._new_life())
+        creature = Creature(pid, parent_end, gene, self._new_life(starting_fuel))
         self.living.append(creature)
         if self.log is not None:
             parent = gene.identity.rsplit('.', 1)[0] if '.' in gene.identity else None
@@ -183,7 +192,9 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         request = json.dumps({'cmd': 'tick',
                               'age': creature.life.age,
                               'fuel': creature.life.fuel,
-                              'max_fuel': creature.life.max_fuel}) + '\n'
+                              'max_fuel': creature.life.max_fuel,
+                              'food_available': self.world.food,
+                              'population': len(self.living)}) + '\n'
         try:
             creature.channel.sendall(request.encode('utf-8'))
         except OSError:
@@ -239,6 +250,7 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
         self.ticks += 1
         self.world.tick()
         newborns = []
+        decisions = []
 
         for creature in list(self.living):
             decision = self.ask(creature)
@@ -251,29 +263,67 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
                 self._kill(creature, 'crashed')
                 continue
 
+            decisions.append(decision)
             creature.life.eat(self.world.request(decision['eat']))
             if decision['reproduce'] and creature.life.can_reproduce:
                 # Newborns are not spawned until the end of the tick, so they
                 # must be counted against the cap here or several births in one
                 # tick can each pass the check and collectively overshoot it.
-                newborns.append(self._breed(creature, pending=len(newborns)))
+                newborns.append(self._breed(creature, decision['endowment'],
+                                            pending=len(newborns)))
             creature.life.tick()
             if not creature.life.alive:
                 self.living.remove(creature)
                 self._kill(creature, creature.life.cause_of_death)
 
-        for gene in filter(None, newborns):
-            self.spawn(gene)
+        for gene, endowment in filter(None, newborns):
+            self.spawn(gene, starting_fuel=endowment)
 
         if self.log is not None:
             self.log.snapshot(tick=self.ticks, population=len(self.living),
-                              food=self.world.food)
+                              food=self.world.food,
+                              strategy=self._strategy(decisions))
 
-    def _breed(self, creature, pending):
+    def _strategy(self, decisions):
+        """ Summarises what the population wanted and what it is made of.
+
+            Two kinds of measurement, deliberately separated. The realised means
+            (eat, breed rate, endowment) mix genetic change with demography: a
+            shifting age distribution changes which decisions get made even if no
+            gene changes. The genetic divergence, the fraction of living
+            creatures that are no longer the unmutated ancestor, is a cleaner
+            signal of actual evolution, since it does not depend on age.
+        :param decisions: The decision dicts collected this tick
+        :return: A strategy dict, or None if nobody is alive
+        """
+        if not decisions and not self.living:
+            return None
+        summary = {
+            'genetic_divergence': (
+                sum(1 for c in self.living if c.gene.source != genome.ANCESTOR_SOURCE)
+                / len(self.living)) if self.living else 0.0,
+        }
+        if decisions:
+            count = len(decisions)
+            summary.update(
+                mean_eat=sum(d['eat'] for d in decisions) / count,
+                breed_rate=sum(1 for d in decisions if d['reproduce']) / count,
+                mean_endowment=sum(d['endowment'] for d in decisions) / count)
+        return summary
+
+    def _breed(self, creature, endowment, pending):
         """ Attempts one birth, respecting the process cap.
+
+            The parent pays two things: the flat reproduction cost, which gates
+            fertility, and the endowment it chose to transfer to the child. The
+            endowment is limited to what the parent has left after the flat cost,
+            since a creature cannot give away fuel it does not have. The child
+            starts with exactly that endowment, which may be zero.
         :param creature: The parent
+        :param endowment: Fuel the parent wants to give the child
         :param pending: Births already agreed this tick but not yet spawned
-        :return: The child Genome, or None if the birth failed or was capped
+        :return: (child Genome, fuel the child starts with), or None if the
+            birth failed or was capped
         """
         if len(self.living) + pending >= self.max_processes:
             self.cap_hits += 1
@@ -291,8 +341,10 @@ class Supervisor:  # pylint: disable=too-many-instance-attributes
                                       parent=creature.gene.identity,
                                       reason='unparseable')
             return None
+        affordable = max(0, min(endowment, creature.life.fuel))
+        creature.life.fuel -= affordable
         self.births += 1
-        return child
+        return child, affordable
 
     def shutdown(self):
         """ Kills and reaps every remaining creature. Safe to call twice.

--- a/creatures/test_ecology.py
+++ b/creatures/test_ecology.py
@@ -46,7 +46,8 @@ def run_population(*, regrowth, ticks=120, founders=20,  # pylint: disable=too-m
                 continue
             try:
                 decision = genome.decide(gene.source, age=life.age, fuel=life.fuel,
-                                         max_fuel=life.max_fuel)
+                                         max_fuel=life.max_fuel,
+                                         food_available=world.food, population=len(pop))
             except genome.MisbehavingCreatureError:
                 life.alive = False
                 deaths['crashed'] += 1
@@ -125,8 +126,11 @@ class TestFoodIsTheLimiter(unittest.TestCase):
         self.assertGreater(rich['deaths']['old_age'], lean['deaths']['old_age'])
 
     def test_too_little_food_ends_in_extinction(self):
-        """The limit has teeth: below replacement, the population dies out."""
-        self.assertTrue(run_population(regrowth=15, ticks=80)['extinct'])
+        """The limit has teeth: below replacement, the population dies out. The
+        threshold moved down sharply when creatures gained a 40 tick lifespan
+        and a cheap reproduction cost, so it now takes near-total starvation
+        (regrowth 5) to force extinction rather than the earlier 15."""
+        self.assertTrue(run_population(regrowth=5, ticks=80)['extinct'])
 
     def test_population_stays_bounded_without_any_cap(self):
         """No cap is passed at all here. If food did not limit growth this

--- a/creatures/test_events.py
+++ b/creatures/test_events.py
@@ -77,6 +77,23 @@ class TestWriting(EventTestCase):
             handle.write('{"kind": "snapshot", "tick": 2, "popula')
         self.assertEqual(1, len(list(events.read(self.path))))
 
+    def test_snapshot_records_the_populations_realised_strategy(self):
+        """The point of widening the decision space: we must be able to see
+        whether the population's strategy drifts from the ancestor."""
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=1, population=3, food=100,
+                         strategy={'mean_eat': 3.5, 'breed_rate': 0.6,
+                                   'mean_endowment': 4.2})
+        event = events.read(self.path)[0]
+        self.assertIn('strategy', event)
+        self.assertAlmostEqual(3.5, event['strategy']['mean_eat'])
+
+    def test_snapshot_strategy_is_optional(self):
+        """A tick with nobody alive has no strategy to record."""
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=1, population=0, food=100)
+        self.assertIsNone(events.read(self.path)[0].get('strategy'))
+
 
 class TestReplay(EventTestCase):
     """Reconstructing a run from its log, with no processes involved."""
@@ -134,6 +151,31 @@ class TestReplay(EventTestCase):
         replay = events.Replay(self.path)
         self.assertEqual([], replay.population_over_time)
         self.assertEqual(0, replay.births)
+
+    def test_strategy_over_time_is_recovered(self):
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=0, population=2, food=100,
+                         strategy={'mean_eat': 3.0, 'breed_rate': 0.5,
+                                   'mean_endowment': 4.0})
+            log.snapshot(tick=1, population=3, food=90,
+                         strategy={'mean_eat': 4.0, 'breed_rate': 0.7,
+                                   'mean_endowment': 5.0})
+        strategy = events.Replay(self.path).strategy_over_time
+        self.assertEqual([3.0, 4.0], [s['mean_eat'] for s in strategy])
+
+    def test_strategy_drift_is_reported(self):
+        """Did the population move away from where it started? This is the
+        difference between a population that evolves and one that just persists."""
+        with events.EventLog(self.path) as log:
+            log.snapshot(tick=0, population=2, food=100,
+                         strategy={'mean_eat': 3.0, 'breed_rate': 0.5,
+                                   'mean_endowment': 4.0})
+            log.snapshot(tick=9, population=2, food=100,
+                         strategy={'mean_eat': 5.0, 'breed_rate': 0.5,
+                                   'mean_endowment': 4.0})
+        drift = events.Replay(self.path).strategy_drift
+        self.assertAlmostEqual(2.0, drift['mean_eat'])
+        self.assertAlmostEqual(0.0, drift['breed_rate'])
 
 
 class TestManifest(EventTestCase):

--- a/creatures/test_genome.py
+++ b/creatures/test_genome.py
@@ -32,74 +32,106 @@ class TestAncestor(unittest.TestCase):
         loaded = genome.load(genome.ANCESTOR_SOURCE)
         self.assertTrue(callable(loaded))
 
-    def test_ancestor_returns_a_decision(self):
-        decision = genome.decide(genome.ANCESTOR_SOURCE, age=1, fuel=5, max_fuel=20)
-        self.assertIn('eat', decision)
-        self.assertIn('reproduce', decision)
+    DECISION_KEYS = ('eat', 'reproduce', 'endowment')
+
+    def decide(self, **overrides):
+        """Run the ancestor with default senses, overriding as needed."""
+        args = {'age': 1, 'fuel': 5, 'max_fuel': 20,
+                'food_available': 100, 'population': 10}
+        args.update(overrides)
+        return genome.decide(genome.ANCESTOR_SOURCE, **args)
+
+    def test_ancestor_returns_a_full_decision(self):
+        decision = self.decide()
+        for key in self.DECISION_KEYS:
+            self.assertIn(key, decision)
 
     def test_ancestor_eats_when_low_on_fuel(self):
-        decision = genome.decide(genome.ANCESTOR_SOURCE, age=1, fuel=1, max_fuel=20)
-        self.assertGreater(decision['eat'], 0)
+        self.assertGreater(self.decide(fuel=1)['eat'], 0)
+
+    def test_ancestor_eats_harder_when_food_is_scarce(self):
+        """A strategy that is only possible now that the creature can see the
+        pool and the population."""
+        plenty = self.decide(fuel=18, food_available=1000, population=5)
+        scarce = self.decide(fuel=18, food_available=2, population=50)
+        self.assertGreater(scarce['eat'], plenty['eat'])
 
     def test_ancestor_asks_to_breed_when_healthy(self):
-        decision = genome.decide(genome.ANCESTOR_SOURCE, age=3, fuel=20, max_fuel=20)
-        self.assertTrue(decision['reproduce'])
+        self.assertTrue(self.decide(age=3, fuel=20)['reproduce'])
 
     def test_ancestor_does_not_ask_to_breed_when_starving(self):
-        decision = genome.decide(genome.ANCESTOR_SOURCE, age=3, fuel=1, max_fuel=20)
-        self.assertFalse(decision['reproduce'])
+        self.assertFalse(self.decide(age=3, fuel=1)['reproduce'])
+
+    def test_ancestor_endows_its_offspring(self):
+        """Offspring investment is the evolvable life-history dial."""
+        self.assertGreater(self.decide(fuel=20)['endowment'], 0)
+
+    def test_a_poorer_parent_endows_less(self):
+        self.assertGreater(self.decide(fuel=40, max_fuel=40)['endowment'],
+                           self.decide(fuel=8, max_fuel=40)['endowment'])
 
     def test_ancestor_does_not_police_its_own_fertility(self):
         """It asks at every age; lifecycle.can_reproduce decides. An earlier
         ancestor hardcoded `2 <= age <= 5`, which capped every creature at two
         breeding attempts no matter what the engine allowed and drove every
         population extinct."""
-        young = genome.decide(genome.ANCESTOR_SOURCE, age=0, fuel=20, max_fuel=20)
-        old = genome.decide(genome.ANCESTOR_SOURCE, age=99, fuel=20, max_fuel=20)
-        self.assertTrue(young['reproduce'])
-        self.assertTrue(old['reproduce'])
+        self.assertTrue(self.decide(age=0, fuel=20)['reproduce'])
+        self.assertTrue(self.decide(age=99, fuel=20)['reproduce'])
 
 
 class TestDecisionNormalising(unittest.TestCase):
     """A mutant can return nonsense. The engine must never trust it."""
 
+    ARGS = {'age': 1, 'fuel': 5, 'max_fuel': 20, 'food_available': 100, 'population': 10}
+    SIG = 'def act(age, fuel, max_fuel, food_available, population):'
+
+    def decide(self, body):
+        """Run a one-line act() body against fixed senses."""
+        return genome.decide(f'{self.SIG}\n    {body}\n', **self.ARGS)
+
     def test_missing_keys_get_defaults(self):
-        source = 'def act(age, fuel, max_fuel):\n    return {}\n'
-        decision = genome.decide(source, age=1, fuel=5, max_fuel=20)
+        decision = self.decide('return {}')
         self.assertEqual(0, decision['eat'])
         self.assertFalse(decision['reproduce'])
+        self.assertEqual(0, decision['endowment'])
 
     def test_negative_eat_is_clamped_to_zero(self):
-        source = 'def act(age, fuel, max_fuel):\n    return {"eat": -50}\n'
-        self.assertEqual(0, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+        self.assertEqual(0, self.decide('return {"eat": -50}')['eat'])
 
     def test_absurd_eat_is_clamped_to_max_fuel(self):
-        source = 'def act(age, fuel, max_fuel):\n    return {"eat": 10 ** 9}\n'
-        self.assertEqual(20, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+        self.assertEqual(20, self.decide('return {"eat": 10 ** 9}')['eat'])
 
     def test_non_numeric_eat_becomes_zero(self):
-        source = 'def act(age, fuel, max_fuel):\n    return {"eat": "lots"}\n'
-        self.assertEqual(0, genome.decide(source, age=1, fuel=5, max_fuel=20)['eat'])
+        self.assertEqual(0, self.decide('return {"eat": "lots"}')['eat'])
+
+    def test_negative_endowment_is_clamped_to_zero(self):
+        self.assertEqual(0, self.decide('return {"endowment": -5}')['endowment'])
+
+    def test_endowment_is_capped(self):
+        """A creature cannot conjure fuel to give away that it does not have."""
+        self.assertLessEqual(self.decide('return {"endowment": 10 ** 9}')['endowment'],
+                             self.ARGS['max_fuel'])
+
+    def test_non_numeric_endowment_becomes_zero(self):
+        self.assertEqual(0, self.decide('return {"endowment": None}')['endowment'])
 
     def test_non_dict_return_is_rejected(self):
-        source = 'def act(age, fuel, max_fuel):\n    return 42\n'
         with self.assertRaises(genome.MisbehavingCreatureError):
-            genome.decide(source, age=1, fuel=5, max_fuel=20)
+            self.decide('return 42')
 
     def test_raising_creature_is_reported_not_propagated(self):
-        source = 'def act(age, fuel, max_fuel):\n    raise ValueError("boom")\n'
         with self.assertRaises(genome.MisbehavingCreatureError):
-            genome.decide(source, age=1, fuel=5, max_fuel=20)
+            self.decide('raise ValueError("boom")')
 
-    def test_infinite_loop_is_not_our_problem_but_wrong_arity_is(self):
-        source = 'def act(only_one_arg):\n    return {}\n'
+    def test_wrong_arity_is_misbehaving(self):
+        """Mutation deletes arguments. A creature that no longer accepts the
+        full call is misbehaving and dies in the world, as before."""
         with self.assertRaises(genome.MisbehavingCreatureError):
-            genome.decide(source, age=1, fuel=5, max_fuel=20)
+            genome.decide('def act(only_one_arg):\n    return {}\n', **self.ARGS)
 
     def test_missing_act_is_rejected(self):
-        source = 'x = 1\n'
         with self.assertRaises(genome.MisbehavingCreatureError):
-            genome.decide(source, age=1, fuel=5, max_fuel=20)
+            genome.decide('x = 1\n', **self.ARGS)
 
 
 class TestSyntaxGate(unittest.TestCase):
@@ -144,6 +176,25 @@ class TestMutation(unittest.TestCase):
                      for s in range(300))
         self.assertLess(viable, 250, 'suspiciously tolerant')
         self.assertGreater(viable, 0, 'nothing survives, so nothing can ever evolve')
+
+    def test_low_mutation_rate_does_not_bias_the_operator(self):
+        """The mutate-or-not coin and the mutation must use independent seeds.
+        Reusing one seed forced every low-probability mutation to be a prepend,
+        which made 97% of mutants unparseable and nearly froze evolution. The
+        parse rate among actual mutations must not depend on the rate."""
+        founder = genome.Genome.founder(seed=42)
+        mutated = attempts = 0
+        for i in range(3000):
+            child = founder.child(birth_index=i, mutation_probability=0.1)
+            if child is None:
+                attempts += 1
+            elif child.source != genome.ANCESTOR_SOURCE:
+                attempts += 1
+                mutated += 1
+        parse_rate = mutated / attempts
+        self.assertGreater(parse_rate, 0.2,
+                           f'only {parse_rate:.0%} of mutations parsed; the coin and '
+                           f'the mutation are probably sharing a seed again')
 
 
 class TestLineage(unittest.TestCase):
@@ -218,8 +269,8 @@ class TestLineage(unittest.TestCase):
 
     def test_child_source_is_a_mutant_of_the_parent(self):
         founder = genome.Genome.founder(seed=42)
-        child = founder.child(birth_index=0)
-        self.assertIsNotNone(child, 'seed 42 index 0 happens to produce a viable child')
+        child = next(c for c in (founder.child(birth_index=i) for i in range(200))
+                     if c is not None)
         self.assertNotEqual(founder.source, child.source)
 
     def test_a_birth_can_fail(self):
@@ -259,7 +310,8 @@ class TestLineage(unittest.TestCase):
             if child is None:
                 continue
             try:
-                genome.decide(child.source, age=3, fuel=5, max_fuel=20)
+                genome.decide(child.source, age=3, fuel=5, max_fuel=20,
+                              food_available=100, population=10)
             except genome.MisbehavingCreatureError:
                 broken += 1
         self.assertGreater(broken, 0,

--- a/creatures/test_supervisor.py
+++ b/creatures/test_supervisor.py
@@ -145,8 +145,10 @@ class TestMisbehavingCreatures(SupervisorTestCase):
 
     def test_a_creature_that_crashes_is_killed_and_recorded(self):
         sup = self.make()
-        broken = genome.Genome('def act(age, fuel, max_fuel):\n    raise ValueError("x")\n',
-                               seed=1, identity='0', generation=1)
+        broken = genome.Genome(
+            'def act(age, fuel, max_fuel, food_available, population):\n'
+            '    raise ValueError("x")\n',
+            seed=1, identity='0', generation=1)
         creature = sup.spawn(broken)
         sup.tick()
         self.assertEqual(1, sup.deaths['crashed'])
@@ -157,7 +159,7 @@ class TestMisbehavingCreatures(SupervisorTestCase):
         """A mutant containing `while True` is inevitable. It must not stall
         the whole run, and it must be distinguishable from a crash."""
         sup = self.make(timeout=0.25)
-        hung = genome.Genome('def act(age, fuel, max_fuel):\n'
+        hung = genome.Genome('def act(age, fuel, max_fuel, food_available, population):\n'
                              '    while True:\n        pass\n',
                              seed=1, identity='0', generation=1)
         creature = sup.spawn(hung)
@@ -172,7 +174,7 @@ class TestMisbehavingCreatures(SupervisorTestCase):
 
     def test_a_timeout_is_not_counted_as_a_crash(self):
         sup = self.make(timeout=0.25)
-        sup.spawn(genome.Genome('def act(age, fuel, max_fuel):\n'
+        sup.spawn(genome.Genome('def act(age, fuel, max_fuel, food_available, population):\n'
                                 '    while True:\n        pass\n',
                                 seed=1, identity='0', generation=1))
         sup.tick()
@@ -182,7 +184,7 @@ class TestMisbehavingCreatures(SupervisorTestCase):
         """Process isolation is the whole reason for forking."""
         sup = self.make(timeout=0.25)
         sup.start(founders=3, seed=1)
-        sup.spawn(genome.Genome('def act(age, fuel, max_fuel):\n'
+        sup.spawn(genome.Genome('def act(age, fuel, max_fuel, food_available, population):\n'
                                 '    while True:\n        pass\n',
                                 seed=99, identity='x', generation=1))
         sup.tick()


### PR DESCRIPTION
Closes #33. A bridge between phase 2 (population works) and phase 3 (2D world).

Creatures now perceive the world and make a life-history choice. `act()` sees `food_available` and `population` on top of its own state, and returns an `endowment` alongside `eat` and `reproduce`: how much of the parent's fuel to transfer to each offspring. That is the r/K dial (many cheap offspring vs few well-provisioned) and it gives mutation a real strategy landscape instead of four lines to break.

## Two bugs that invalidated an earlier measurement

**The mutate-or-not coin and the mutation shared a seed.** Filtering to seeds whose first `random()` is below the probability, then reseeding the mutation with that same value, forced `_flawed_copy`'s first draw into the same low range and always selected the first operator, `prepend`. At `mutation_probability` 0.1 that made **97% of mutants unparseable** and nearly froze evolution. Independent seeds now, parse rate back to 37% regardless of rate. New regression test pins it.

**Endowment made reproduction double-charge.** A flat cost of 20 plus the endowment drained a parent to zero on the tick it bred, so it starved. The endowment is now the real cost of reproduction (fuel transferred, not lost), so the flat cost drops to **2**, a small overhead that still gates fertility. Steady state returns: peak ~285, settles ~113, all three death causes present. `reproduction_cost` is now a `Supervisor` parameter, because Python binds default arguments once and a module constant could not be swept (which silently invalidated my first tuning sweep).

## The measurement, which is the point of the phase

Each tick's snapshot records the population's realised strategy **and, separately, its genetic divergence**: the fraction of living creatures no longer carrying the unmutated ancestor. Keeping these apart matters because realised-strategy drift mixes evolution with demography, while divergence does not.

**The honest result, seed 1 over 200 ticks:**

```
genetic divergence over run: [0.0, 0.02, 0.0, 0.04, 0.06, 0.09, 0.10, 0.05]
mean_eat over run:           [6.0, 5.98, 5.89, 5.08, 5.41, 5.60, 5.86, 5.33]
```

Genetic divergence stays between 0 and 10% and ends near 5%. **The population persists as near-clones of the ancestor. It is surviving, not meaningfully evolving.** The realised `mean_eat` drift of -0.56 is almost entirely the age structure, not selection.

That is a real finding, not a disappointment, and it is a direct input to the error-threshold question in #30: at this mutation rate on this brittle substrate, mutants mostly die before they can establish. Whether to push mutation up toward the threshold, cheapen survival for mutants, or treat near-clonal persistence as the result is a genuine research choice for after this merges.

```
129 creature tests, 63 legacy tests, all green
10.00/10 under pylint
```

Also useful for later: `python -m creatures.run --replay DIR` now prints genetic divergence and strategy drift.