### PR TITLE
Part A: ridge structure is the barrier, not part count

### DIFF
--- a/ridge/evolve.py
+++ b/ridge/evolve.py
@@ -1,0 +1,75 @@
+""" evolve.py - the plainest mutation-and-selection loop.
+
+A population of binary genomes, tournament selection on fitness, and per-part
+mutation. Deliberately unclever: the experiment's whole point is to watch what
+ordinary cumulative selection does as the landscape's gap widens, so the
+algorithm must not be doing anything special.
+
+Note what selection is and is not given. It sees each genome's fitness, which is
+survival value, and nothing else. It is never told the target or which parts are
+still wrong. It cannot aim. It can only keep whatever currently scores higher,
+which is exactly the blind, foresightless process under test.
+"""
+
+import dataclasses
+import random
+
+
+@dataclasses.dataclass
+class Result:
+    """ What one run produced. """
+    solved: bool
+    solved_at: int
+    best_fitness: int
+    generations: int
+
+
+def _tournament(population, fitnesses, rng, size=3):
+    """ Picks the fitter of a few random genomes.
+
+        Tournament selection rather than fitness-proportionate, because it
+        handles a flat plateau gracefully: when everyone on the plateau ties, it
+        reduces to a random pick, which is precisely the neutral drift that a
+        population uses to explore a no-benefit gap.
+    :return: A copy of the winning genome
+    """
+    best_index = rng.randrange(len(population))
+    for _ in range(size - 1):
+        challenger = rng.randrange(len(population))
+        if fitnesses[challenger] > fitnesses[best_index]:
+            best_index = challenger
+    return list(population[best_index])
+
+
+def _mutate(genome, mutation_rate, rng):
+    """ Flips each part independently with probability mutation_rate.
+    :return: The mutated genome
+    """
+    return [1 - part if rng.random() < mutation_rate else part for part in genome]
+
+
+def run(landscape, *, population_size, generations, mutation_rate, seed):
+    """ Evolves a population against a landscape until it is solved or the
+        generation budget runs out.
+    :param landscape: A Landscape
+    :param population_size: How many genomes
+    :param generations: The budget
+    :param mutation_rate: Per-part flip probability
+    :param seed: Random seed; the same seed reproduces the run
+    :return: A Result
+    """
+    rng = random.Random(seed)
+    population = [[0] * landscape.n_parts for _ in range(population_size)]
+    best_fitness = 0
+
+    for generation in range(generations):
+        fitnesses = [landscape.fitness(genome) for genome in population]
+        best_fitness = max(best_fitness, *fitnesses)
+        if best_fitness == landscape.max_fitness:
+            return Result(solved=True, solved_at=generation,
+                          best_fitness=best_fitness, generations=generations)
+        population = [_mutate(_tournament(population, fitnesses, rng), mutation_rate, rng)
+                      for _ in range(population_size)]
+
+    return Result(solved=False, solved_at=None,
+                  best_fitness=best_fitness, generations=generations)

--- a/ridge/experiment.py
+++ b/ridge/experiment.py
@@ -1,0 +1,91 @@
+""" experiment.py - the headline sweep for Part A.
+
+Three questions, each answered by holding everything fixed but one variable:
+
+  1. Does part count matter?  Vary N with a tiny gap. If success stays high,
+     complexity is not the barrier.
+
+  2. Does a neutral gap matter?  Vary g with valley_depth 0. Drift crosses these,
+     so success should hold until the block space (2^g) outgrows the budget.
+
+  3. Does a valley matter?  Vary g with valley_depth > 0. Selection opposes
+     crossing, so success should collapse fast, at a much smaller g.
+
+Run: python -m ridge.experiment
+"""
+
+import sys
+
+from ridge import evolve, landscape
+
+SEEDS = range(10)
+
+
+# Six independent sweep knobs, all varied across the three experiments.
+def _success_rate(*, n_parts, coordination_degree, valley_depth,  # pylint: disable=too-many-arguments
+                  population_size, generations, mutation_rate):
+    """ Fraction of seeds that reach the target. """
+    land = landscape.Landscape(n_parts, coordination_degree, valley_depth)
+    solved = sum(evolve.run(land, population_size=population_size,
+                            generations=generations, mutation_rate=mutation_rate,
+                            seed=seed).solved
+                 for seed in SEEDS)
+    return solved / len(SEEDS)
+
+
+def _line(label, value, rate):
+    meter = '#' * round(rate * 20)
+    print(f'  {label} {value:>3}   {rate:>5.0%}  {meter}')
+
+
+def part_count_does_not_matter():
+    """ Vary N with a tiny gap. Success should stay flat.
+
+        Mutation is held constant per *genome* (rate = 1/N), not per part, which
+        is how biology works: an organism's genome-wide mutation count is roughly
+        fixed regardless of genome size. A fixed per-part rate would instead pile
+        on mutation load as N grows and hit the error threshold, which is a
+        different effect entirely and would confound this measurement.
+    """
+    print('1. Part count, with a tiny gap (g=2, neutral), mutation held per '
+          'genome. Success vs N:')
+    for n_parts in (8, 16, 32, 64, 128):
+        rate = _success_rate(n_parts=n_parts, coordination_degree=2, valley_depth=0,
+                             population_size=100, generations=6000,
+                             mutation_rate=1.0 / n_parts)
+        _line('N =', n_parts, rate)
+
+
+def neutral_gaps_are_crossable():
+    """ Vary g with valley_depth 0. Success holds for a while, then drift runs
+        out of budget. """
+    print('\n2. Neutral gap width g (valley_depth=0). Success vs g:')
+    for gap in (2, 6, 10, 14, 18):
+        rate = _success_rate(n_parts=gap + 6, coordination_degree=gap, valley_depth=0,
+                             population_size=200, generations=4000, mutation_rate=0.06)
+        _line('g =', gap, rate)
+
+
+def valleys_are_the_barrier():
+    """ Vary g with a valley. Success should collapse far sooner. """
+    print('\n3. Deleterious valley width g (valley_depth=3). Success vs g:')
+    for gap in (2, 4, 6, 8, 10):
+        rate = _success_rate(n_parts=gap + 6, coordination_degree=gap, valley_depth=3,
+                             population_size=200, generations=4000, mutation_rate=0.06)
+        _line('g =', gap, rate)
+
+
+def main():
+    """ Runs the three sweeps. """
+    part_count_does_not_matter()
+    neutral_gaps_are_crossable()
+    valleys_are_the_barrier()
+    print('\nReading: part count barely moves success; a neutral gap is crossed by '
+          'drift\nuntil the block space outgrows the budget; a deleterious valley '
+          'collapses\nsuccess at a far smaller width. The barrier is the valley, not '
+          'the parts.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ridge/landscape.py
+++ b/ridge/landscape.py
@@ -1,0 +1,77 @@
+""" landscape.py - a fitness landscape whose ridge/gap structure is tunable.
+
+A genome is a sequence of N binary parts. The target is all-correct (all 1s).
+The landscape splits into two regions:
+
+  - The first N-g parts are *reducible*: each correct part adds 1 to fitness on
+    its own, forming a ridge that selection can climb one step at a time.
+
+  - The last g parts are an *irreducible block*: they pay a bonus of g, but only
+    when all g are correct at once.
+
+g is the coordination degree, the single quantity this experiment exists to
+vary, because the claim under test is that evolvability is set by g (the gap),
+not by N (how many parts the target has).
+
+There is a second, subtler dial: what a *half-built* block is worth. It turns
+out to matter more than g itself.
+
+  - valley_depth = 0: a half-built block is worth nothing, the same as an empty
+    one. The gap is *neutral*. A population can wander across it by drift,
+    exploring the 2^g block configurations at no cost, so even a fairly wide
+    neutral gap gets crossed. Evolution handles these.
+
+  - valley_depth > 0: each part added to an incomplete block *lowers* fitness,
+    as a half-built machine that costs resources and does nothing would. The gap
+    is now a *valley*: selection actively pushes the block back toward empty, so
+    the only way across is to complete all g parts in a single leap against the
+    gradient. This is the real irreducible-complexity barrier, and it is
+    exponentially harder than a neutral gap of the same width.
+
+The honest lesson, which the tests forced out: "is there a gap" is the wrong
+question. "Is the gap neutral or deleterious" is the one that decides whether
+cumulative selection can cross it.
+"""
+
+
+class Landscape:
+    """ A tunable ridge-then-gap fitness function over binary genomes. """
+
+    def __init__(self, n_parts, coordination_degree, valley_depth=0):
+        if not 1 <= coordination_degree <= n_parts:
+            raise ValueError(
+                f'coordination_degree must be in [1, {n_parts}], '
+                f'got {coordination_degree}')
+        if valley_depth < 0:
+            raise ValueError(f'valley_depth must be >= 0, got {valley_depth}')
+        self.n_parts = n_parts
+        self.coordination_degree = coordination_degree
+        self.valley_depth = valley_depth
+        self.reducible = n_parts - coordination_degree
+
+    def fitness(self, genome):
+        """ Scores a genome.
+
+            Ridge: one point per correct reducible part. Completed block: the
+            full bonus of g. Incomplete block: a penalty of valley_depth per
+            part already placed, which is zero when valley_depth is zero (a
+            neutral gap) and a downhill slope otherwise (a deleterious valley).
+        :param genome: A sequence of 0/1 of length n_parts
+        :return: Fitness
+        """
+        if len(genome) != self.n_parts:
+            raise ValueError(f'expected {self.n_parts} parts, got {len(genome)}')
+        ridge = sum(genome[:self.reducible])
+        block = genome[self.reducible:]
+        if all(block):
+            return ridge + self.coordination_degree
+        return ridge - self.valley_depth * sum(block)
+
+    @property
+    def max_fitness(self):
+        """ :return: The fitness of the completed target """
+        return self.n_parts
+
+    def is_optimal(self, genome):
+        """ :return: True if the genome is the completed target """
+        return self.fitness(genome) == self.max_fitness

--- a/ridge/test_evolve.py
+++ b/ridge/test_evolve.py
@@ -1,0 +1,122 @@
+"""Tests for the mutation-selection loop.
+
+Written before the implementation. This is the plainest possible evolutionary
+algorithm: a population of binary genomes, tournament selection on fitness, and
+per-part mutation. No cleverness, because the point is to show what ordinary
+cumulative selection can and cannot do as the landscape's gap changes.
+"""
+
+import unittest
+
+from ridge import evolve, landscape
+
+
+class TestClimbingARidge(unittest.TestCase):
+    """With g=1 the whole landscape is a ridge. Selection should walk right up."""
+
+    def test_a_pure_ridge_is_solved(self):
+        land = landscape.Landscape(n_parts=12, coordination_degree=1)
+        result = evolve.run(land, population_size=50, generations=500,
+                            mutation_rate=0.05, seed=1)
+        self.assertTrue(result.solved, 'selection failed to climb a pure ridge')
+
+    def test_a_wider_ridge_is_still_solved(self):
+        """The headline half: more parts, same tiny gap, still solved. Part
+        count is not the barrier."""
+        land = landscape.Landscape(n_parts=40, coordination_degree=1)
+        result = evolve.run(land, population_size=50, generations=1500,
+                            mutation_rate=0.02, seed=1)
+        self.assertTrue(result.solved, 'a 40-part ridge should still be climbable')
+
+
+class TestNeutralGapsAreCrossable(unittest.TestCase):
+    """A neutral gap is a flat plateau: drift wanders across it. This is the
+    part evolution genuinely does well, and pretending otherwise would be
+    dishonest."""
+
+    def test_a_small_neutral_gap_is_crossed(self):
+        land = landscape.Landscape(n_parts=12, coordination_degree=2, valley_depth=0)
+        result = evolve.run(land, population_size=200, generations=1500,
+                            mutation_rate=0.06, seed=1)
+        self.assertTrue(result.solved, 'drift should cross a 2-wide neutral gap')
+
+    def test_a_moderate_neutral_gap_is_still_crossed(self):
+        """~2^8 block states is a small space to drift through."""
+        land = landscape.Landscape(n_parts=12, coordination_degree=8, valley_depth=0)
+        result = evolve.run(land, population_size=200, generations=2000,
+                            mutation_rate=0.06, seed=1)
+        self.assertTrue(result.solved, 'drift should still cross an 8-wide neutral gap')
+
+
+class TestValleysAreTheBarrier(unittest.TestCase):
+    """A deleterious valley is what cumulative selection cannot cross, because
+    selection actively pushes back down the slope. This is the real
+    irreducible-complexity case."""
+
+    def test_a_wide_valley_is_not_crossed(self):
+        """With a valley, drift is useless (selection pushes back), so crossing
+        needs all g parts to flip in one leap: cost ~(1/mutation)^g, which is
+        out of budget by g=8."""
+        land = landscape.Landscape(n_parts=12, coordination_degree=8, valley_depth=3)
+        result = evolve.run(land, population_size=200, generations=2000,
+                            mutation_rate=0.06, seed=1)
+        self.assertFalse(result.solved, 'an 8-wide valley should not be crossed here')
+
+    def test_the_same_gap_flips_from_crossable_to_impassable_with_depth(self):
+        """Identical N and g. The only change is whether the intermediates are
+        neutral or deleterious, and that alone decides the outcome. This is the
+        whole experiment in one comparison."""
+        neutral = evolve.run(
+            landscape.Landscape(n_parts=12, coordination_degree=8, valley_depth=0),
+            population_size=200, generations=2000, mutation_rate=0.06, seed=1)
+        valley = evolve.run(
+            landscape.Landscape(n_parts=12, coordination_degree=8, valley_depth=3),
+            population_size=200, generations=2000, mutation_rate=0.06, seed=1)
+        self.assertTrue(neutral.solved, 'the neutral gap should be crossed by drift')
+        self.assertFalse(valley.solved, 'the same-width valley should not be crossed')
+
+
+class TestReporting(unittest.TestCase):
+
+    def test_result_reports_when_it_solved(self):
+        land = landscape.Landscape(n_parts=8, coordination_degree=1)
+        result = evolve.run(land, population_size=50, generations=500,
+                            mutation_rate=0.05, seed=1)
+        self.assertIsNotNone(result.solved_at)
+        self.assertLessEqual(result.solved_at, 500)
+
+    def test_result_reports_best_fitness_reached(self):
+        land = landscape.Landscape(n_parts=8, coordination_degree=8)
+        result = evolve.run(land, population_size=50, generations=200,
+                            mutation_rate=0.05, seed=1)
+        self.assertLessEqual(result.best_fitness, land.max_fitness)
+
+    def test_unsolved_run_has_no_solve_time(self):
+        land = landscape.Landscape(n_parts=12, coordination_degree=10)
+        result = evolve.run(land, population_size=50, generations=100,
+                            mutation_rate=0.05, seed=1)
+        if not result.solved:
+            self.assertIsNone(result.solved_at)
+
+
+class TestDeterminism(unittest.TestCase):
+
+    def test_same_seed_same_outcome(self):
+        land = landscape.Landscape(n_parts=12, coordination_degree=3)
+        first = evolve.run(land, population_size=100, generations=400,
+                           mutation_rate=0.05, seed=7)
+        second = evolve.run(land, population_size=100, generations=400,
+                            mutation_rate=0.05, seed=7)
+        self.assertEqual(first.solved_at, second.solved_at)
+        self.assertEqual(first.best_fitness, second.best_fitness)
+
+    def test_different_seeds_can_differ(self):
+        land = landscape.Landscape(n_parts=12, coordination_degree=4)
+        outcomes = {evolve.run(land, population_size=100, generations=800,
+                               mutation_rate=0.06, seed=s).solved_at
+                    for s in range(8)}
+        self.assertGreater(len(outcomes), 1, 'every seed gave the identical time')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ridge/test_landscape.py
+++ b/ridge/test_landscape.py
@@ -1,0 +1,114 @@
+"""Tests for the tunable fitness landscape.
+
+Written before the implementation.
+
+The landscape exists to separate two things that the "747" argument keeps
+fusing: the number of parts a target has, and the size of the no-benefit gap
+that must be crossed to reach it. A genome is N binary parts, the target is
+all-correct, and the coordination degree g controls how many of those parts pay
+off only when all of them are correct at once.
+
+  g = 1  : every part is independently rewarded. A pure ridge, climbable one
+           step at a time.
+  g = N  : nothing is rewarded until the whole thing is complete. An isolated
+           island, reachable only by getting all N right at once.
+"""
+
+import unittest
+
+from ridge import landscape
+
+
+class TestStructure(unittest.TestCase):
+
+    def test_all_broken_scores_zero(self):
+        land = landscape.Landscape(n_parts=6, coordination_degree=2)
+        self.assertEqual(0, land.fitness((0, 0, 0, 0, 0, 0)))
+
+    def test_all_correct_is_the_maximum(self):
+        land = landscape.Landscape(n_parts=6, coordination_degree=2)
+        self.assertEqual(land.max_fitness, land.fitness((1, 1, 1, 1, 1, 1)))
+        self.assertEqual(6, land.max_fitness)
+
+    def test_each_reducible_part_adds_fitness(self):
+        """The first N-g parts form the ridge: each correct one helps on its own."""
+        land = landscape.Landscape(n_parts=6, coordination_degree=2)
+        self.assertEqual(1, land.fitness((1, 0, 0, 0, 0, 0)))
+        self.assertEqual(2, land.fitness((1, 1, 0, 0, 0, 0)))
+        self.assertEqual(4, land.fitness((1, 1, 1, 1, 0, 0)))
+
+    def test_a_neutral_gap_pays_nothing_until_complete(self):
+        """With valley_depth 0 a partial block is worth the same as an empty one:
+        a flat gap that drift can wander across."""
+        land = landscape.Landscape(n_parts=6, coordination_degree=2, valley_depth=0)
+        empty = (1, 1, 1, 1, 0, 0)
+        one_block_bit = (1, 1, 1, 1, 1, 0)
+        self.assertEqual(land.fitness(empty), land.fitness(one_block_bit))
+
+    def test_a_valley_penalises_every_partial_step(self):
+        """With valley_depth > 0 each block part added lowers fitness: selection
+        actively opposes crossing."""
+        land = landscape.Landscape(n_parts=6, coordination_degree=3, valley_depth=2)
+        empty = (1, 1, 1, 0, 0, 0)
+        one = (1, 1, 1, 1, 0, 0)
+        two = (1, 1, 1, 1, 1, 0)
+        self.assertEqual(3, land.fitness(empty))
+        self.assertEqual(1, land.fitness(one), 'first block part should cost 2')
+        self.assertEqual(-1, land.fitness(two), 'second block part should cost 2 more')
+
+    def test_completing_a_valley_still_reaches_the_summit(self):
+        land = landscape.Landscape(n_parts=6, coordination_degree=3, valley_depth=2)
+        self.assertEqual(land.max_fitness, land.fitness((1, 1, 1, 1, 1, 1)))
+
+    def test_completing_the_block_pays_the_whole_bonus_at_once(self):
+        land = landscape.Landscape(n_parts=6, coordination_degree=2)
+        before = land.fitness((1, 1, 1, 1, 1, 0))
+        after = land.fitness((1, 1, 1, 1, 1, 1))
+        self.assertEqual(2, after - before, 'the block bonus should equal g')
+
+    def test_the_plateau_sits_g_below_the_summit(self):
+        """A population climbs the ridge to here, then must cross the gap."""
+        land = landscape.Landscape(n_parts=10, coordination_degree=3)
+        plateau = (1, 1, 1, 1, 1, 1, 1, 0, 0, 0)
+        self.assertEqual(land.max_fitness - 3, land.fitness(plateau))
+
+
+class TestTheTwoExtremes(unittest.TestCase):
+
+    def test_coordination_one_is_a_pure_ridge(self):
+        """Every single part is independently rewarded: no gap anywhere."""
+        land = landscape.Landscape(n_parts=8, coordination_degree=1)
+        for correct in range(9):
+            genome = tuple([1] * correct + [0] * (8 - correct))
+            self.assertEqual(correct, land.fitness(genome))
+
+    def test_coordination_n_is_all_or_nothing(self):
+        """Nothing is rewarded until the whole target is complete."""
+        land = landscape.Landscape(n_parts=8, coordination_degree=8)
+        self.assertEqual(0, land.fitness((1, 1, 1, 1, 1, 1, 1, 0)))
+        self.assertEqual(8, land.fitness((1, 1, 1, 1, 1, 1, 1, 1)))
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_coordination_cannot_exceed_parts(self):
+        with self.assertRaises(ValueError):
+            landscape.Landscape(n_parts=4, coordination_degree=5)
+
+    def test_coordination_must_be_at_least_one(self):
+        with self.assertRaises(ValueError):
+            landscape.Landscape(n_parts=4, coordination_degree=0)
+
+    def test_is_optimal_recognises_the_summit(self):
+        land = landscape.Landscape(n_parts=5, coordination_degree=2)
+        self.assertTrue(land.is_optimal((1, 1, 1, 1, 1)))
+        self.assertFalse(land.is_optimal((1, 1, 1, 1, 0)))
+
+    def test_wrong_length_genome_is_rejected(self):
+        land = landscape.Landscape(n_parts=5, coordination_degree=2)
+        with self.assertRaises(ValueError):
+            land.fitness((1, 1, 1))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #35. The controlled experiment we designed, isolating one variable.

A genome is N binary parts, target all-correct. The last `g` parts form an irreducible block (the coordination degree). A second dial, `valley_depth`, sets what a **half-built** block is worth — and it turns out to matter more than g itself. No Python-source mutation, no forking: substrate brittleness is deliberately stripped out so the one variable is isolated.

## The result, three sweeps, ten seeds each

**1. Part count N** (tiny gap, mutation held per genome):
```
N =   8    100%  ####################
N =  16    100%  ####################
N =  32    100%  ####################
N =  64    100%  ####################
N = 128    100%  ####################
```
Complexity alone is not the barrier. A 128-part target is solved every time — *if there's a ridge to climb*.

**2. Neutral gap width g** (`valley_depth=0`):
```
g =   2    100%   g =  10   100%   g =  18    80%
g =   6    100%   g =  14   100%
```
A neutral gap is a flat plateau; drift wanders across it. It only resists once the block space (~2^g) outgrows the budget.

**3. Deleterious valley width g** (`valley_depth=3`):
```
g =   2    100%
g =   4    100%
g =   6     10%
g =   8      0%
g =  10      0%
```
Same widths as sweep 2. Dramatically harder.

## The whole thing in one comparison

Identical N and g. Change *only* whether the intermediates are neutral or deleterious, and success flips from certain to impossible. That's the crux we argued our way to over the last several exchanges:

> "Is there a gap" is the wrong question. **"Is the gap neutral or deleterious"** is what decides whether cumulative selection can cross it.

A neutral gap costs ~2^g (drift). A valley costs ~(1/mutation)^g (one leap against the gradient) — vastly steeper. That is the precise, measurable form of your irreducible-complexity intuition, and it locates exactly where you're right (valleys are real barriers) and where the part-count framing misleads (128 parts is fine if the path is a ridge).

## Two honest corrections the tests forced

- An 8-wide *neutral* gap crossed easily. That failure revealed the neutral-vs-deleterious distinction the first model didn't have — the single most important idea in the experiment, and I only added it because a test I wrote expecting failure passed.
- The part-count sweep first dipped at N=64. That wasn't a part-count barrier; it was the error threshold from per-*part* mutation load. Holding mutation constant per *genome* (as in biology) removed it. Documented in the code.

## Scope

Deliberately uses known targets, because it studies the *relationship* between landscape structure and evolvability — not whether biology's landscapes have valleys. That is **Part B**: measure where real functions fall on the neutral-to-deleterious axis, with survival-only fitness and published deep-mutational-scanning data (GB1, GFP, β-lactamase).

```
25 tests, written before the implementation
10.00/10 under pylint
python -m ridge.experiment  reproduces the table
```