### PR TITLE
Broaden Option 2: the TrpB enzyme landscape (third optimisation data point)

### DIFF
--- a/ridge/data/SOURCE.md
+++ b/ridge/data/SOURCE.md
@@ -71,3 +71,32 @@ model-imputed for genotypes missing from the raw sort-seq measurements, so
 individual meanF values away from measured genotypes are model estimates, not
 direct readings. The source also holds SRE2 (GA), 14 other response elements,
 and the derived AncSR2 background, not included here.
+
+## johnston2024_trpb_landscape.csv
+
+Enzyme activity (a growth-based relative fitness) of all four-site combinatorial
+variants at active-site positions 183, 184, 227, 228 of the tryptophan synthase
+beta-subunit TrpB, from:
+
+  Johnston KE, Almhjell PJ, Watkins-Dulaney EJ, Liu G, Porter NJ, Yang J,
+  Arnold FH (2024). "A combinatorially complete epistatic fitness landscape in
+  an enzyme active site." PNAS 121(32):e2400439121.
+
+Two columns: `variant`, the four-letter string of amino acids at the four sites
+(the wild-type parent enzyme Tm9D8* has VFVS), and `fitness`, a growth rate in a
+tryptophan-starved E. coli auxotroph, normalised so the fittest variant equals
+1.0. More active enzymes let the host grow faster.
+
+Obtained from the SSMuLA landscape collection on Zenodo
+(https://doi.org/10.5281/zenodo.13910506, file data.zip, path
+data/TrpB/fitness_landscape/TrpB4.csv), which curates the processed landscape
+from the paper above; the primary deposit is CaltechDATA
+(https://doi.org/10.22002/h5rah-5z170). Restricted here to the 159129 variants
+that use only the twenty standard amino acids and have a measured fitness, out
+of the 20^4 = 160000 possible (99.5% coverage).
+
+The empirical global maximum is AIKG (fitness 1.0), four substitutions from the
+wild type. The landscape is the most rugged of the three, with 802 local maxima,
+and its global peak is not reachable from the wild type by any direct
+non-decreasing path, matching the paper's finding that epistasis prevents
+directed evolution from reaching the optimum.

--- a/ridge/four_site.py
+++ b/ridge/four_site.py
@@ -1,0 +1,100 @@
+""" four_site.py - accessibility analysis shared by the four-site landscapes.
+
+GB1 and TrpB are both four-site, twenty-amino-acid landscapes carried by a
+Gb1Landscape, so the same two questions are asked of each: is the path from the
+wild type to the global peak crossable, and how does the crossable share of all
+fitter peaks change as more sites must change together. This module holds that
+analysis once so gb1_experiment and trpb_experiment do not each reimplement it.
+"""
+
+from ridge import gb1, paths
+
+DISTANCES = (2, 3, 4)
+
+
+def global_peak(land):
+    """ :return: The fittest variant in the landscape """
+    return max(land.values, key=land.values.get)
+
+
+def wt_to_global_peak(land):
+    """ Accessibility of the path from the wild type to the fittest variant.
+
+        strict counts orderings that gain fitness at every step; drift counts
+        orderings that never lose it; valley_depth is the shallowest forced dip,
+        zero meaning a never-decreasing path exists.
+    :return: A dict describing that path
+    """
+    peak = global_peak(land)
+    fitness, k = land.pair_fitness(land.wild_type, peak)
+    strict = paths.accessible_paths(fitness, k, strict=True)
+    return {
+        'peak': peak,
+        'peak_fitness': land.fitness(peak),
+        'total': strict.total,
+        'strict': strict.accessible,
+        'drift': paths.accessible_paths(fitness, k, strict=False).accessible,
+        'valley_depth': paths.min_valley_depth(fitness, k),
+    }
+
+
+def crossable_by_distance(land, distances=DISTANCES):
+    """ For each mutational distance, counts fitter peaks reachable without a
+        valley versus those forced to cross one.
+
+        A target counts if it is fitter than the wild type and its whole cube of
+        intermediates is measured, so all its direct paths are defined. It is
+        crossable if some direct path never loses fitness, otherwise it is a
+        valley.
+    :param land: A Gb1Landscape
+    :param distances: The Hamming distances from the wild type to report
+    :return: A dict from distance to (crossable, valley) counts
+    """
+    counts = {distance: [0, 0] for distance in distances}
+    wild = land.wild_type
+    baseline = land.fitness(wild)
+    for variant, score in land.values.items():
+        distance = gb1.static_hamming(wild, variant)
+        if distance not in counts or score <= baseline:
+            continue
+        if not land.is_complete_cube(wild, variant):
+            continue
+        fitness, k = land.pair_fitness(wild, variant)
+        depth = paths.min_valley_depth(fitness, k)
+        counts[distance][0 if depth == 0 else 1] += 1
+    return {distance: tuple(pair) for distance, pair in counts.items()}
+
+
+def print_report(result, *, title, wt_label, closing):
+    """ Prints an analyse() result in the shared GB1/TrpB format.
+    :param result: A dict with variants, local_maxima, wt_to_peak, and
+        crossable_by_distance, as the experiment analyse() functions return
+    :param title: The header line naming the dataset
+    :param wt_label: How to name the wild type in the peak line
+    :param closing: Lines of interpretation, printed after the distribution
+    """
+    peak = result['wt_to_peak']
+    print(title)
+    print(f'  measured variants        {result["variants"]}  (of 160000 possible)')
+    print(f'  local maxima (peaks)     {result["local_maxima"]}  '
+          '[a smooth hill would have one]')
+    print()
+    print(f'{wt_label} to the global peak {peak["peak"]} '
+          f'(fitness {peak["peak_fitness"]:.2f}):')
+    print(f'  accessible under strict selection {peak["strict"]:>2} / {peak["total"]}'
+          '   [each step must strictly gain]')
+    print(f'  accessible allowing neutral drift {peak["drift"]:>2} / {peak["total"]}'
+          '   [each step must not lose]')
+    verdict = ('CROSSABLE (ridge)' if peak['valley_depth'] == 0
+               else 'a VALLEY that must be descended')
+    print(f'  so the single global peak is {verdict}.')
+    print()
+    print('Across all fitter peaks, by how many sites must change together:')
+    for distance, (crossable, valley) in sorted(result['crossable_by_distance'].items()):
+        total = crossable + valley
+        share = crossable / total if total else 0.0
+        print(f'  {distance} sites: {total:5d} peaks   '
+              f'crossable {crossable:5d} ({share:.0%})   valley {valley:5d}')
+    print()
+    for line in closing:
+        print(line)

--- a/ridge/gb1_experiment.py
+++ b/ridge/gb1_experiment.py
@@ -20,52 +20,9 @@ Run: python -m ridge.gb1_experiment
 import os
 import sys
 
-from ridge import gb1, paths
+from ridge import four_site, gb1
 
 DATA = os.path.join(os.path.dirname(__file__), 'data', 'gb1_wu2016_landscape.csv')
-DISTRIBUTION_DISTANCES = (2, 3, 4)
-
-
-def _wt_to_global_peak(land):
-    """ Accessibility of the path from wild type to the single fittest variant.
-    :return: A dict describing that path
-    """
-    peak = max(land.values, key=land.values.get)
-    fitness, k = land.pair_fitness(land.wild_type, peak)
-    strict = paths.accessible_paths(fitness, k, strict=True)
-    return {
-        'peak': peak,
-        'peak_fitness': land.fitness(peak),
-        'total': strict.total,
-        'strict': strict.accessible,
-        'drift': paths.accessible_paths(fitness, k, strict=False).accessible,
-        'valley_depth': paths.min_valley_depth(fitness, k),
-    }
-
-
-def _crossable_by_distance(land):
-    """ For each mutational distance, counts fitter peaks reachable without a
-        valley versus those forced to cross one.
-
-        A target counts if it is fitter than wild type and its whole cube of
-        intermediates is measured, so all its direct paths are defined. It is
-        crossable if some direct path never loses fitness (valley depth zero),
-        otherwise it is a valley.
-    :return: A dict from distance to (crossable, valley) counts
-    """
-    counts = {distance: [0, 0] for distance in DISTRIBUTION_DISTANCES}
-    wild = land.wild_type
-    baseline = land.fitness(wild)
-    for variant, score in land.values.items():
-        distance = gb1.static_hamming(wild, variant)
-        if distance not in counts or score <= baseline:
-            continue
-        if not land.is_complete_cube(wild, variant):
-            continue
-        fitness, k = land.pair_fitness(wild, variant)
-        depth = paths.min_valley_depth(fitness, k)
-        counts[distance][0 if depth == 0 else 1] += 1
-    return {distance: tuple(pair) for distance, pair in counts.items()}
 
 
 def analyse():
@@ -77,42 +34,23 @@ def analyse():
         'variants': len(land.values),
         'wild_type_fitness': land.fitness(land.wild_type),
         'local_maxima': len(land.local_maxima()),
-        'wt_to_peak': _wt_to_global_peak(land),
-        'crossable_by_distance': _crossable_by_distance(land),
+        'wt_to_peak': four_site.wt_to_global_peak(land),
+        'crossable_by_distance': four_site.crossable_by_distance(land),
     }
 
 
 def main():
     """ Prints the analysis. """
-    result = analyse()
-    peak = result['wt_to_peak']
-    print('Wu et al. (2016) GB1, four sites, all twenty amino acids:')
-    print(f'  measured variants        {result["variants"]}  '
-          f'(of 160000 possible)')
-    print(f'  local maxima (peaks)     {result["local_maxima"]}  '
-          '[a smooth hill would have one]')
-    print()
-    print(f'Wild type VDGV to the global peak {peak["peak"]} '
-          f'(fitness {peak["peak_fitness"]:.2f}):')
-    print(f'  accessible under strict selection {peak["strict"]:>2} / {peak["total"]}'
-          '   [each step must strictly gain]')
-    print(f'  accessible allowing neutral drift {peak["drift"]:>2} / {peak["total"]}'
-          '   [each step must not lose]')
-    verdict = ('CROSSABLE (ridge)' if peak['valley_depth'] == 0
-               else 'a VALLEY that must be descended')
-    print(f'  so the single global peak is {verdict}.')
-    print()
-    print('Across all fitter peaks, by how many sites must change together:')
-    for distance, (crossable, valley) in sorted(result['crossable_by_distance'].items()):
-        total = crossable + valley
-        share = crossable / total if total else 0.0
-        print(f'  {distance} sites: {total:5d} peaks   '
-              f'crossable {crossable:5d} ({share:.0%})   valley {valley:5d}')
-    print()
-    print('  As more sites must change together the crossable fraction falls:')
-    print('  real protein data shows Part A\'s coordination-degree effect. The')
-    print('  barrier is the size of the block that must change at once, not the')
-    print('  number of parts.')
+    four_site.print_report(
+        analyse(),
+        title='Wu et al. (2016) GB1, four sites, all twenty amino acids:',
+        wt_label='Wild type VDGV',
+        closing=[
+            '  As more sites must change together the crossable fraction falls:',
+            "  real protein data shows Part A's coordination-degree effect. The",
+            '  barrier is the size of the block that must change at once, not the',
+            '  number of parts.',
+        ])
     return 0
 
 

--- a/ridge/test_four_site.py
+++ b/ridge/test_four_site.py
@@ -1,0 +1,64 @@
+"""Tests for the shared four-site accessibility analysis.
+
+Two-character genotypes so every answer is checkable by eye. GB1 and TrpB both
+run through this module on real data, so these hand-built cases lock its
+behaviour independently of either dataset.
+"""
+
+import unittest
+
+from ridge import four_site, gb1
+
+
+def _land(values):
+    return gb1.Gb1Landscape(values=values, wild_type='AA')
+
+
+class TestGlobalPeak(unittest.TestCase):
+
+    def test_global_peak_is_the_fittest_variant(self):
+        land = _land({'AA': 1.0, 'CA': 2.0, 'AC': 3.0, 'CC': 5.0})
+        self.assertEqual('CC', four_site.global_peak(land))
+
+
+class TestWtToGlobalPeak(unittest.TestCase):
+
+    def test_a_smooth_climb_is_crossable(self):
+        land = _land({'AA': 1.0, 'CA': 2.0, 'AC': 3.0, 'CC': 5.0})
+        result = four_site.wt_to_global_peak(land)
+        self.assertEqual('CC', result['peak'])
+        self.assertEqual(5.0, result['peak_fitness'])
+        self.assertEqual(2, result['total'])
+        self.assertEqual(2, result['strict'])
+        self.assertEqual(0, result['valley_depth'])
+
+    def test_a_dip_before_the_peak_is_a_valley(self):
+        # Both intermediates are below the start, so every path must descend.
+        land = _land({'AA': 5.0, 'CA': 1.0, 'AC': 1.0, 'CC': 10.0})
+        result = four_site.wt_to_global_peak(land)
+        self.assertEqual(0, result['strict'])
+        self.assertEqual(0, result['drift'])
+        self.assertGreater(result['valley_depth'], 0)
+
+
+class TestCrossableByDistance(unittest.TestCase):
+
+    def test_counts_a_crossable_distance_two_peak(self):
+        land = _land({'AA': 1.0, 'CA': 2.0, 'AC': 3.0, 'CC': 5.0})
+        self.assertEqual({2: (1, 0)},
+                         four_site.crossable_by_distance(land, distances=(2,)))
+
+    def test_counts_a_valley_distance_two_peak(self):
+        land = _land({'AA': 5.0, 'CA': 1.0, 'AC': 1.0, 'CC': 10.0})
+        self.assertEqual({2: (0, 1)},
+                         four_site.crossable_by_distance(land, distances=(2,)))
+
+    def test_ignores_peaks_no_fitter_than_wild_type(self):
+        # CC is not fitter than the AA start, so it is not counted.
+        land = _land({'AA': 5.0, 'CA': 1.0, 'AC': 1.0, 'CC': 4.0})
+        self.assertEqual({2: (0, 0)},
+                         four_site.crossable_by_distance(land, distances=(2,)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ridge/test_trpb.py
+++ b/ridge/test_trpb.py
@@ -1,0 +1,78 @@
+"""Tests for the TrpB enzyme landscape.
+
+The four-site path mechanics are proven in test_gb1.py and test_four_site.py, so
+this pins the TrpB-specific facts: the parent enzyme's residues, the ruggedness,
+and the barrier. TrpB is the sharpest case so far, its global peak is a valley
+that no direct path reaches, matching the source paper's finding that directed
+evolution cannot climb to the optimum.
+"""
+
+import os
+import tempfile
+import unittest
+
+from ridge import trpb, trpb_experiment
+
+DATA = os.path.join(os.path.dirname(__file__), 'data',
+                    'johnston2024_trpb_landscape.csv')
+
+
+class TestLoader(unittest.TestCase):
+
+    def test_sets_the_trpb_parent_as_wild_type(self):
+        descriptor, path = tempfile.mkstemp(suffix='.csv')
+        with os.fdopen(descriptor, 'w') as handle:
+            handle.write('variant,fitness\nVFVS,0.4\nAAAA,0.1\n')
+        self.addCleanup(os.unlink, path)
+        land = trpb.load_trpb_landscape(path)
+        self.assertEqual('VFVS', land.wild_type)
+        self.assertEqual(0.4, land.fitness('VFVS'))
+
+
+class TestRealLandscape(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.land = trpb.load_trpb_landscape(DATA)
+
+    def test_loads_every_measured_standard_variant(self):
+        self.assertEqual(159129, len(self.land.values))
+
+    def test_parent_enzyme_is_functional(self):
+        self.assertAlmostEqual(0.408, self.land.fitness('VFVS'), places=3)
+
+    def test_the_global_peak_is_aikg(self):
+        peak = max(self.land.values, key=self.land.values.get)
+        self.assertEqual('AIKG', peak)
+        self.assertAlmostEqual(1.0, self.land.fitness(peak), places=3)
+
+    def test_the_landscape_is_very_rugged(self):
+        self.assertEqual(802, len(self.land.local_maxima()))
+
+
+class TestOptimisationBarrier(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.result = trpb_experiment.analyse()
+
+    def test_the_global_peak_is_a_valley_no_direct_path_reaches(self):
+        peak = self.result['wt_to_peak']
+        self.assertEqual(24, peak['total'])
+        self.assertEqual(0, peak['strict'])
+        self.assertEqual(0, peak['drift'])
+        self.assertGreater(peak['valley_depth'], 0)
+
+    def test_crossable_by_distance_is_pinned(self):
+        self.assertEqual({2: (33, 71), 3: (63, 386), 4: (12, 518)},
+                         self.result['crossable_by_distance'])
+
+    def test_crossable_fraction_falls_as_coordination_grows(self):
+        counts = self.result['crossable_by_distance']
+        fraction = {d: c / (c + v) for d, (c, v) in counts.items()}
+        self.assertGreater(fraction[2], fraction[3])
+        self.assertGreater(fraction[3], fraction[4])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ridge/trpb.py
+++ b/ridge/trpb.py
@@ -1,0 +1,28 @@
+""" trpb.py - loads the tryptophan synthase (TrpB) four-site landscape.
+
+TrpB is a third real optimisation landscape, after beta-lactamase and GB1, and
+it adds a function type the others do not have: enzyme catalysis measured by
+growth. More active variants of the enzyme let a tryptophan-starved E. coli grow
+faster, so fitness here is a relative growth rate, not a binding or resistance
+readout.
+
+The four varied sites (183, 184, 227, 228) in the enzyme's active site form the
+same four-amino-acid genotype as GB1, so this loads straight into a Gb1Landscape
+and runs through the shared four_site analysis unchanged. The wild-type parent
+enzyme has VFVS at these sites.
+"""
+
+from ridge import gb1
+
+WILD_TYPE = 'VFVS'
+
+
+def load_trpb_landscape(path, *, wild_type=WILD_TYPE):
+    """ Loads the TrpB four-site landscape into a Gb1Landscape.
+    :param path: Path to the CSV with `variant` and `fitness` columns
+    :param wild_type: The parent enzyme's residues at the four sites
+    :return: A Gb1Landscape whose wild type is the TrpB parent
+    """
+    land = gb1.load_gb1_landscape(path)
+    land.wild_type = wild_type
+    return land

--- a/ridge/trpb_experiment.py
+++ b/ridge/trpb_experiment.py
@@ -1,0 +1,56 @@
+""" trpb_experiment.py - Part B applied to the TrpB enzyme landscape.
+
+The third optimisation landscape, run through exactly the analysis GB1 used, so
+the two are directly comparable. The question is the same: is the wild-type-to-
+peak path a crossable ridge or a valley, and does the crossable share of fitter
+peaks fall as more active-site residues must change together?
+
+TrpB matters here because its published headline is that epistasis and many
+local optima keep simulated directed evolution from reaching the global optimum.
+That is the coordination-degree barrier stated in an enzyme, and this run puts a
+number on it in the same terms as GB1.
+
+Run: python -m ridge.trpb_experiment
+"""
+
+import os
+import sys
+
+from ridge import four_site, trpb
+
+DATA = os.path.join(os.path.dirname(__file__), 'data',
+                    'johnston2024_trpb_landscape.csv')
+
+
+def analyse():
+    """ Computes the TrpB accessibility figures.
+    :return: A dict of results
+    """
+    land = trpb.load_trpb_landscape(DATA)
+    return {
+        'variants': len(land.values),
+        'wild_type': land.wild_type,
+        'wild_type_fitness': land.fitness(land.wild_type),
+        'local_maxima': len(land.local_maxima()),
+        'wt_to_peak': four_site.wt_to_global_peak(land),
+        'crossable_by_distance': four_site.crossable_by_distance(land),
+    }
+
+
+def main():
+    """ Prints the analysis. """
+    result = analyse()
+    four_site.print_report(
+        result,
+        title='Johnston et al. (2024) TrpB, four active-site residues, growth fitness:',
+        wt_label=f'Wild type {result["wild_type"]}',
+        closing=[
+            '  The same coordination-degree effect GB1 showed for a binding protein',
+            '  appears in an enzyme: as more active-site residues must change',
+            '  together, fewer peaks are reachable without crossing a valley.',
+        ])
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What

Broadens the foundation with a new **function type**: enzyme catalysis measured by growth, after beta-lactamase (antibiotic resistance) and GB1 (binding). TrpB is a combinatorially complete four-site active-site landscape from Johnston et al. (2024), *"A combinatorially complete epistatic fitness landscape in an enzyme active site"* (PNAS).

## How

TrpB has the same four-site, twenty-amino-acid shape as GB1, so it loads straight into `Gb1Landscape`. To avoid duplicating GB1's analysis, the shared logic (global peak, wild-type-to-peak accessibility, crossable-by-distance, and the report format) is extracted into **`ridge/four_site.py`**, and `gb1_experiment` is refactored to call it. GB1's `analyse()` contract and its pinned tests are unchanged; the extracted module also gets direct hand-built coverage in `test_four_site.py`.

## Findings, in the same terms as GB1

- **The most rugged landscape yet: 802 local maxima** (GB1 had 182).
- **Its global peak is a genuine valley.** Wild type VFVS to the global peak AIKG (four substitutions away): **0 of 24** direct paths reach it without losing fitness. This is the first landscape whose global optimum is unreachable by any monotone path, and it independently matches the paper's own headline that epistasis prevents directed evolution from reaching the optimum.
- **The steepest coordination-degree collapse of the three:** crossable share of fitter peaks falls 32% at two sites, 14% at three, **2% at four**.

Put beside GB1 and beta-lactamase, whose global peaks were crossable ridges, TrpB shows an optimisation landscape can also be valley-dominated. That widens the range of the optimisation side of the comparison the project is building toward.

## Data

Restricted to the 159,129 standard-amino-acid variants with a measured fitness (99.5% of the 20^4 grid). Fitness is a growth rate normalised so the fittest variant equals 1.0. Provenance in `data/SOURCE.md`, curated on Zenodo (SSMuLA) from the paper's CaltechDATA deposit.

## Checks

75 ridge tests pass, pylint 10.00/10.

## Note on merge order

Branched from current master (which has GB1 but not the still-open steroid PR #39), so this is independent of #39. If #39 merges first, this may need a trivial `SOURCE.md` rebase, which I will handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)