### PR TITLE
Option 3 phase 1: the biological DFE calibration target

### DIFF
--- a/ridge/dfe.py
+++ b/ridge/dfe.py
@@ -1,0 +1,104 @@
+""" dfe.py - the distribution of fitness effects, measured from real landscapes.
+
+This is the calibration target for the simulation. Before asking how much
+functional complexity mutation and selection can build in a Python substrate, we
+have to know how forgiving real molecules are, so we can make the substrate no
+more forgiving and no less.
+
+Forgiveness here is about survival, not marginal fitness. Starting from a working
+genotype, a single mutation either keeps it working (tolerated) or breaks it
+(disruptive). That split is scale-free, so it is comparable across landscapes whose
+fitness is measured in different units, and it is the quantity a substrate's
+mutation tolerance must be dialled to match. Among the tolerated mutations we
+also count how many actually improve fitness (beneficial), the raw material
+selection has to work with.
+
+The DFE is measured *from functional backgrounds*, not from all genotypes. The
+effect of a mutation depends entirely on where you start: from a broken genotype
+almost anything is neutral or better, from a working one most changes hurt. Only
+the second question calibrates a substrate, so a background counts only if it is
+at least as fit as the functional threshold (the wild type by default).
+"""
+
+import dataclasses
+import statistics
+
+
+@dataclasses.dataclass
+class Dfe:
+    """ The survival split of single mutations from functional backgrounds. """
+    tolerated: int
+    disruptive: int
+    beneficial: int
+    median_deleterious_effect: float
+
+    @property
+    def total(self):
+        """ :return: How many single-mutation steps were measured """
+        return self.tolerated + self.disruptive
+
+    @property
+    def fraction_tolerated(self):
+        """ :return: Share of mutations that keep the genotype functional, the
+            forgiveness the substrate must match (0 with no data) """
+        return self.tolerated / self.total if self.total else 0.0
+
+    @property
+    def fraction_disruptive(self):
+        """ :return: Share of mutations that drop below the functional
+            threshold (0 with no data) """
+        return self.disruptive / self.total if self.total else 0.0
+
+    @property
+    def fraction_beneficial(self):
+        """ :return: Share of mutations that improve fitness (0 with no data) """
+        return self.beneficial / self.total if self.total else 0.0
+
+
+def measure(values, neighbours_of, *, functional_threshold):
+    """ Measures the DFE from every functional background in a landscape.
+
+        A background is functional if its fitness is at least
+        functional_threshold. Each of its measured single-mutation neighbours is
+        one step: tolerated if the neighbour is still at or above the threshold,
+        otherwise disruptive, and additionally beneficial if the neighbour is fitter
+        than the background.
+    :param values: A dict from genotype to fitness
+    :param neighbours_of: A callable from a genotype to its measured single-
+        mutation neighbours
+    :param functional_threshold: Minimum fitness for a genotype to be functional
+    :return: A Dfe
+    """
+    tolerated = disruptive = beneficial = 0
+    deleterious_effects = []
+    for parent, parent_fitness in values.items():
+        if parent_fitness < functional_threshold:
+            continue
+        for child in neighbours_of(parent):
+            child_fitness = values[child]
+            if child_fitness >= functional_threshold:
+                tolerated += 1
+                if child_fitness > parent_fitness:
+                    beneficial += 1
+                else:
+                    deleterious_effects.append(parent_fitness - child_fitness)
+            else:
+                disruptive += 1
+    median = statistics.median(deleterious_effects) if deleterious_effects else 0.0
+    return Dfe(tolerated=tolerated, disruptive=disruptive, beneficial=beneficial,
+               median_deleterious_effect=median)
+
+
+def measure_landscape(land, *, functional_threshold=None):
+    """ Measures the DFE of a four-site landscape from its functional core.
+
+        Convenience wrapper for a Gb1Landscape-shaped object: its `values` dict
+        and `neighbours` method, with the wild-type fitness as the default
+        functional threshold.
+    :param land: An object with `.values`, `.neighbours`, `.wild_type`, `.fitness`
+    :return: A Dfe
+    """
+    if functional_threshold is None:
+        functional_threshold = land.fitness(land.wild_type)
+    return measure(land.values, land.neighbours,
+                   functional_threshold=functional_threshold)

--- a/ridge/dfe_experiment.py
+++ b/ridge/dfe_experiment.py
@@ -1,0 +1,64 @@
+""" dfe_experiment.py - the biological calibration target for the simulation.
+
+Phase one of Option 3. Measures how forgiving real molecules are to single
+mutations, across the three landscapes that have a functional wild type
+(GB1 binding, TrpB catalysis, and the steroid receptor's ancestral ERE
+function). The headline is the tolerated fraction: starting from a working
+genotype, how often does a single mutation leave it still working. That number,
+not a guess, is what the mutable-Python substrate in the next phase must match.
+
+Run: python -m ridge.dfe_experiment
+"""
+
+import os
+import sys
+
+from ridge import dfe, gb1, steroid, trpb
+
+DATA = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def _systems():
+    """ :return: A list of (label, landscape) for the functional-wild-type
+        landscapes used as calibration targets """
+    gb1_land = gb1.load_gb1_landscape(os.path.join(DATA, 'gb1_wu2016_landscape.csv'))
+    trpb_land = trpb.load_trpb_landscape(
+        os.path.join(DATA, 'johnston2024_trpb_landscape.csv'))
+    ancsr1 = steroid.load_ancsr1(os.path.join(DATA, 'herrera2025_ancSR1_RH.csv.gz'))
+    return [
+        ('GB1 binding', gb1_land),
+        ('TrpB catalysis', trpb_land),
+        ('steroid receptor, ancestral ERE function', ancsr1.ere),
+    ]
+
+
+def analyse():
+    """ Measures the DFE of each calibration system.
+    :return: A dict from label to its Dfe
+    """
+    return {label: dfe.measure_landscape(land) for label, land in _systems()}
+
+
+def main():
+    """ Prints the calibration target. """
+    results = analyse()
+    print('Biological forgiveness to single mutations, from functional backgrounds:')
+    print('(tolerated = the mutant is still at least as fit as the wild type)')
+    print()
+    for label, result in results.items():
+        print(f'  {label}:')
+        print(f'    single-mutation steps measured  {result.total}')
+        print(f'    tolerated                        {result.fraction_tolerated:6.1%}')
+        print(f'    disruptive                       {result.fraction_disruptive:6.1%}')
+        print(f'    of which beneficial              {result.fraction_beneficial:6.1%}')
+        print()
+    tolerated = [r.fraction_tolerated for r in results.values()]
+    print(f'Calibration target: a mutable substrate should tolerate roughly '
+          f'{min(tolerated):.0%} to {max(tolerated):.0%}')
+    print('of single mutations, not ~0% (naive code mutation) and not ~100%. The')
+    print('next phase dials the substrate into this range before any scaling runs.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ridge/test_dfe.py
+++ b/ridge/test_dfe.py
@@ -1,0 +1,88 @@
+"""Tests for the distribution of fitness effects, the simulation's calibration
+target.
+
+Correctness is established on a tiny landscape where every step is countable by
+hand. The real-data figures are pinned as regression and checked against the
+scientific claim: biological forgiveness to single mutations is well below 100%
+and well above 0%, and it varies by system.
+"""
+
+import unittest
+
+from ridge import dfe, dfe_experiment, gb1
+
+
+class TestOnAHandBuiltLandscape(unittest.TestCase):
+    """Two-character genotypes, wild type AA with fitness 1.0 as the threshold.
+
+    Functional backgrounds (fitness >= 1.0): AA, CA, GA. AC at 0.5 is disruptive
+    as a neighbour and never used as a background. Counting every present single
+    step by hand gives 6 tolerated, 1 disruptive, 2 beneficial.
+    """
+
+    def _land(self):
+        return gb1.Gb1Landscape(
+            values={'AA': 1.0, 'CA': 2.0, 'AC': 0.5, 'GA': 1.0}, wild_type='AA')
+
+    def test_counts_match_hand_calculation(self):
+        result = dfe.measure_landscape(self._land())
+        self.assertEqual(6, result.tolerated)
+        self.assertEqual(1, result.disruptive)
+        self.assertEqual(2, result.beneficial)
+        self.assertEqual(7, result.total)
+
+    def test_fractions_match_hand_calculation(self):
+        result = dfe.measure_landscape(self._land())
+        self.assertAlmostEqual(6 / 7, result.fraction_tolerated)
+        self.assertAlmostEqual(1 / 7, result.fraction_disruptive)
+        self.assertAlmostEqual(2 / 7, result.fraction_beneficial)
+
+    def test_median_deleterious_effect(self):
+        # Tolerated-but-not-beneficial steps have effects [0, 1, 1, 0]; median 0.5.
+        self.assertAlmostEqual(0.5, dfe.measure_landscape(self._land())
+                               .median_deleterious_effect)
+
+    def test_threshold_can_be_overridden(self):
+        # With a threshold of 2.0 only CA is a functional background.
+        result = dfe.measure_landscape(self._land(), functional_threshold=2.0)
+        # CA's present neighbours AA (1.0) and GA (1.0) are both below 2.0.
+        self.assertEqual(0, result.tolerated)
+        self.assertEqual(2, result.disruptive)
+
+    def test_empty_when_no_functional_background(self):
+        result = dfe.measure_landscape(self._land(), functional_threshold=99.0)
+        self.assertEqual(0, result.total)
+        self.assertEqual(0.0, result.fraction_tolerated)
+
+
+class TestCalibrationTarget(unittest.TestCase):
+    """The real numbers, pinned, and the claim that matters for Option 3."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.results = dfe_experiment.analyse()
+
+    def test_pinned_counts(self):
+        gb1_dfe = self.results['GB1 binding']
+        self.assertEqual((92216, 179790, 46107), (gb1_dfe.tolerated,
+                         gb1_dfe.disruptive, gb1_dfe.beneficial))
+        trpb_dfe = self.results['TrpB catalysis']
+        self.assertEqual((18542, 64448, 9271), (trpb_dfe.tolerated,
+                         trpb_dfe.disruptive, trpb_dfe.beneficial))
+
+    def test_forgiveness_is_between_zero_and_one_everywhere(self):
+        for result in self.results.values():
+            self.assertGreater(result.fraction_tolerated, 0.0)
+            self.assertLess(result.fraction_tolerated, 1.0)
+
+    def test_forgiveness_varies_by_system(self):
+        # Binding is more forgiving than catalysis, which is more forgiving than
+        # the transcription factor's ancestral function.
+        tolerated = {label: r.fraction_tolerated for label, r in self.results.items()}
+        self.assertGreater(tolerated['GB1 binding'], tolerated['TrpB catalysis'])
+        self.assertGreater(tolerated['TrpB catalysis'],
+                           tolerated['steroid receptor, ancestral ERE function'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Phase 1 of Option 3 (the calibrated simulation). Before we ask how much functional complexity mutation and selection can build in a mutable-Python substrate, we have to know how forgiving real molecules are, so we can make the substrate no more forgiving and no less. This PR extracts that calibration target from the four-site landscapes we already loaded.

## The definition, and why

Forgiveness is defined by **survival, not marginal fitness**. From a functional background, a single mutation is *tolerated* if the mutant is still at least as fit as the wild type, otherwise *disruptive*. Two deliberate choices:

- **Scale-free.** The tolerated/disruptive split is a fraction, so it is comparable across landscapes whose fitness is measured in different units (binding enrichment, growth rate, fluorescence).
- **Measured only from functional backgrounds.** The effect of a mutation depends entirely on where it starts: from a broken genotype almost anything is neutral or better; from a working one most changes hurt. Only the second question calibrates a substrate.

## The calibration target

| system | single-mutation steps | tolerated | of which beneficial |
| --- | --- | --- | --- |
| GB1 binding | 272,006 | 33.9% | 17.0% |
| TrpB catalysis | 82,990 | 22.3% | 11.2% |
| steroid receptor, ancestral ERE | 2,432 | 6.5% | 3.2% |

So a fair substrate should tolerate roughly **6% to 34%** of single mutations: not ~0% (naive code mutation, where almost any edit throws an exception) and not ~100%. Phase 2 will dial the mutable-Python substrate into this range *before* any scaling runs, which is the guardrail that keeps us from rigging the difficulty in either direction.

## Honest notes

- The tolerated fraction depends on where the functional threshold sits; here it is the wild-type fitness, a clean default, and `measure` takes the threshold as a parameter so phase 2 can test sensitivity.
- The steroid *new* function (SRE) is excluded here because its wild type is non-functional; that is the origin case, handled separately, not a calibration background.

## Checks

Correctness proven on a hand-built landscape where every step is countable by hand; real counts pinned as regression. 94 ridge tests pass, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)