### PR TITLE
Option 3 phase 2: substrate tolerance is already in biology's range

### DIFF
--- a/sim/substrate.py
+++ b/sim/substrate.py
@@ -1,0 +1,59 @@
+""" substrate.py - the mutable Python-program substrate for Option 3.
+
+Option 3 asks whether mutation and selection can build functional complexity in a
+self-modifying Python program held to a substrate no more forgiving than biology.
+The program is a creature genome: Python source defining act(). This module is
+the thin substrate layer, reusing creatures.genome: the ancestor, one single
+mutation, and a functional/behaviour evaluation.
+
+Functional here is the same survival bar biology's tolerance was measured
+against in ridge.dfe: the source parses, defines act(), and runs without error on
+a fixed grid of input contexts. It says nothing about the quality of the
+behaviour, only that the program does not crash. Two functional programs that
+return the same decision on every context have the same behaviour; a mutation
+that changes any decision changed behaviour.
+"""
+
+import itertools
+
+from creatures import genome
+
+ANCESTOR = genome.ANCESTOR_SOURCE
+
+# A systematic grid of input contexts, so a mutation that changes behaviour on
+# any input is detected, not just on a lucky few. max_fuel is the fixed ceiling;
+# the other four senses are swept across low, middle and high values.
+_AGES = (0, 2, 5)
+_FUELS = (1, 5, 9)
+_FOODS = (0, 10, 100)
+_POPULATIONS = (1, 10)
+CONTEXTS = tuple(
+    {'age': age, 'fuel': fuel, 'max_fuel': 10,
+     'food_available': food, 'population': population}
+    for age, fuel, food, population
+    in itertools.product(_AGES, _FUELS, _FOODS, _POPULATIONS))
+
+
+def evaluate(source):
+    """ Runs a program across every context and returns its behaviour.
+    :param source: Candidate program source
+    :return: A hashable behaviour fingerprint (the decisions on every context),
+        or None if the program is not functional
+    """
+    if not genome.is_viable(source):
+        return None
+    try:
+        return tuple(tuple(sorted(genome.decide(source, **context).items()))
+                     for context in CONTEXTS)
+    except genome.MisbehavingCreatureError:
+        return None
+
+
+def is_functional(source):
+    """ :return: True if the source parses, defines act(), and runs everywhere """
+    return evaluate(source) is not None
+
+
+def mutate_once(source, seed):
+    """ :return: One single mutation of the source, deterministic for a seed """
+    return genome.mutate_source(source, seed)

--- a/sim/test_substrate.py
+++ b/sim/test_substrate.py
@@ -1,0 +1,60 @@
+"""Tests for the mutable Python-program substrate."""
+
+import unittest
+
+from sim import substrate
+
+# A minimal program that accepts the full call and returns a valid decision.
+FUNCTIONAL = ('def act(age, fuel, max_fuel, food_available, population):\n'
+              '    return {"eat": 1, "reproduce": False, "endowment": 0}\n')
+
+
+class TestFunctionality(unittest.TestCase):
+
+    def test_the_ancestor_is_functional(self):
+        self.assertTrue(substrate.is_functional(substrate.ANCESTOR))
+
+    def test_a_minimal_valid_program_is_functional(self):
+        self.assertTrue(substrate.is_functional(FUNCTIONAL))
+
+    def test_a_syntax_error_is_not_functional(self):
+        self.assertFalse(substrate.is_functional('def act('))
+
+    def test_missing_act_is_not_functional(self):
+        self.assertFalse(substrate.is_functional('x = 1'))
+
+    def test_wrong_arity_is_not_functional(self):
+        # decide() calls act with five arguments; a one-argument act raises.
+        self.assertFalse(substrate.is_functional('def act(age):\n    return 1\n'))
+
+
+class TestBehaviour(unittest.TestCase):
+
+    def test_evaluate_is_none_for_a_broken_program(self):
+        self.assertIsNone(substrate.evaluate('def act('))
+
+    def test_evaluate_covers_every_context(self):
+        fingerprint = substrate.evaluate(FUNCTIONAL)
+        self.assertIsNotNone(fingerprint)
+        self.assertEqual(len(substrate.CONTEXTS), len(fingerprint))
+
+    def test_the_same_source_has_the_same_fingerprint(self):
+        self.assertEqual(substrate.evaluate(FUNCTIONAL), substrate.evaluate(FUNCTIONAL))
+
+    def test_changed_behaviour_gives_a_different_fingerprint(self):
+        other = FUNCTIONAL.replace('"eat": 1', '"eat": 2')
+        self.assertNotEqual(substrate.evaluate(FUNCTIONAL), substrate.evaluate(other))
+
+
+class TestMutation(unittest.TestCase):
+
+    def test_a_seed_is_deterministic(self):
+        self.assertEqual(substrate.mutate_once(substrate.ANCESTOR, 7),
+                         substrate.mutate_once(substrate.ANCESTOR, 7))
+
+    def test_returns_source_text(self):
+        self.assertIsInstance(substrate.mutate_once(substrate.ANCESTOR, 1), str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sim/test_tolerance.py
+++ b/sim/test_tolerance.py
@@ -1,0 +1,49 @@
+"""Tests for the substrate's mutation tolerance.
+
+The pinned counts depend on the mutation RNG and so are a reproducibility
+regression; the claim that matters is that the substrate's single-mutation
+tolerance falls inside the biological range measured in ridge.dfe (6% to 34%).
+"""
+
+import unittest
+
+from sim import substrate, tolerance
+
+
+class TestSubstrateTolerance(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.result = tolerance.analyse()
+
+    def test_pinned_counts(self):
+        self.assertEqual(3000, self.result.total)
+        self.assertEqual(315, self.result.functional)
+        self.assertEqual(173, self.result.synonymous)
+        self.assertEqual(142, self.result.behaviour_changing)
+
+    def test_functional_splits_into_synonymous_and_changing(self):
+        self.assertEqual(self.result.functional,
+                         self.result.synonymous + self.result.behaviour_changing)
+
+    def test_tolerance_is_within_the_biological_range(self):
+        # ridge.dfe: 6.5% (steroid) to 33.9% (GB1).
+        self.assertGreaterEqual(self.result.fraction, 0.06)
+        self.assertLessEqual(self.result.fraction, 0.34)
+
+    def test_a_meaningful_share_of_tolerated_mutations_change_behaviour(self):
+        # Not just synonymous no-ops: the substrate has explorable variation.
+        self.assertGreater(self.result.behaviour_changing, 0)
+
+
+class TestMeasureIsDeterministic(unittest.TestCase):
+
+    def test_two_short_runs_agree(self):
+        first = tolerance.measure(substrate.ANCESTOR, trials=50)
+        second = tolerance.measure(substrate.ANCESTOR, trials=50)
+        self.assertEqual((first.functional, first.synonymous),
+                         (second.functional, second.synonymous))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sim/tolerance.py
+++ b/sim/tolerance.py
@@ -1,0 +1,101 @@
+""" tolerance.py - the substrate's mutation tolerance, in biology's terms.
+
+Phase 2 of Option 3. Before running the substrate, we check how forgiving it is
+and compare that to the biological target from ridge.dfe. The measurement is the
+same one: from the functional ancestor, what fraction of single mutations leave
+it functional (survival), and of those, how many are synonymous (behaviour
+unchanged) versus behaviour-changing.
+
+The result is a surprise worth stating plainly. Naive character-level mutation of
+Python source, long assumed far too harsh to be like biology, actually tolerates
+about a tenth of single mutations, inside the 6% to 34% range measured for real
+proteins. And of the tolerated mutations a large share change behaviour, so the
+tolerance is not just no-op edits to comments and whitespace. At the single-
+mutation level the substrate does not need to be made more forgiving. Whether
+that tolerance supports cumulative building is the separate question phase 3
+asks.
+"""
+
+import dataclasses
+import sys
+
+from ridge import dfe_experiment
+from sim import substrate
+
+DEFAULT_TRIALS = 3000
+
+
+@dataclasses.dataclass
+class Tolerance:
+    """ The survival split of single mutations from a functional program. """
+    functional: int
+    synonymous: int
+    behaviour_changing: int
+    total: int
+
+    @property
+    def fraction(self):
+        """ :return: Share of single mutations that stay functional """
+        return self.functional / self.total if self.total else 0.0
+
+
+def measure(source, *, trials=DEFAULT_TRIALS, start_seed=0):
+    """ Measures the tolerance of a source over a run of single mutations.
+
+        Each seed gives one deterministic single mutation. A mutation is counted
+        functional if the mutant still runs on every context, and within that as
+        synonymous if its behaviour fingerprint matches the parent or behaviour-
+        changing if it differs.
+    :param source: The functional parent program
+    :param trials: How many single mutations to sample
+    :param start_seed: First mutation seed (the run is seeds start..start+trials)
+    :return: A Tolerance
+    """
+    parent_behaviour = substrate.evaluate(source)
+    functional = synonymous = changing = 0
+    for seed in range(start_seed, start_seed + trials):
+        behaviour = substrate.evaluate(substrate.mutate_once(source, seed))
+        if behaviour is None:
+            continue
+        functional += 1
+        if behaviour == parent_behaviour:
+            synonymous += 1
+        else:
+            changing += 1
+    return Tolerance(functional=functional, synonymous=synonymous,
+                     behaviour_changing=changing, total=trials)
+
+
+def analyse(*, trials=DEFAULT_TRIALS):
+    """ Measures the substrate's tolerance from the ancestor.
+    :return: A Tolerance
+    """
+    return measure(substrate.ANCESTOR, trials=trials)
+
+
+def _biological_range():
+    """ :return: (min, max) tolerated fraction across the calibration systems """
+    fractions = [dfe.fraction_tolerated for dfe in dfe_experiment.analyse().values()]
+    return min(fractions), max(fractions)
+
+
+def main():
+    """ Prints the substrate tolerance beside the biological target. """
+    result = analyse()
+    low, high = _biological_range()
+    print('Substrate mutation tolerance (self-modifying Python), from the ancestor:')
+    print(f'  single mutations sampled     {result.total}')
+    print(f'  functional (tolerated)       {result.functional}  '
+          f'({result.fraction:.1%})')
+    print(f'    of which behaviour-changing {result.behaviour_changing}')
+    print(f'    of which synonymous         {result.synonymous}')
+    print()
+    print(f'Biological target (ridge.dfe): {low:.0%} to {high:.0%} tolerated.')
+    verdict = ('inside' if low <= result.fraction <= high else 'outside')
+    print(f'The substrate is {verdict} the biological range. Naive Python mutation')
+    print('is not, as assumed, far harsher than biology at the single-mutation level.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What

Phase 2 of Option 3. Measures how forgiving the self-modifying Python substrate is to single mutations, in the same survival terms `ridge.dfe` measured for real proteins, so the two are directly comparable.

The substrate is the creature genome (Python source defining `act()`), reused through a thin new `sim.substrate` layer: a functional/behaviour evaluation and one single mutation. "Functional" is the same survival bar as biology: the program parses, defines `act()`, and runs without error on a fixed grid of 54 input contexts.

## The result, which corrects a founding assumption

Naive character-level mutation of Python source, long assumed far too harsh to resemble biology (and the reason the project worried it was "making it too hard"), actually tolerates **315 of 3000 single mutations (10.5%)**, squarely inside the **6% to 34%** range measured for GB1, TrpB, and the steroid receptor.

And the tolerance is not just no-op edits. Of the 315 tolerated mutations, **142 change behaviour** across the context grid versus **173 synonymous**, so there is a real pool of consequential-but-viable variation for selection to act on.

| | value |
| --- | --- |
| single mutations sampled | 3000 |
| functional (tolerated) | 315 (10.5%) |
| of which behaviour-changing | 142 |
| of which synonymous | 173 |
| biological range (ridge.dfe) | 6% to 34% |

**So at the single-mutation level the substrate does not need to be made more forgiving to match biology.** That is a genuinely useful, slightly counterintuitive finding, and it means Phase 3 can proceed without hand-tuning a tolerance dial (which would have been a bias risk).

## Honest scope

- This is single-mutation **survival** tolerance only. It says nothing yet about whether that tolerance supports **cumulative** building of complexity, which is exactly the scaling question Phase 3 asks.
- "Behaviour-changing" is measured across a 54-context grid; a mutation neutral on all of them is counted synonymous. A finer grid could reclassify a few.
- The mutation grain (source operators, mostly single-character) is a close but not exact analogue of a single-residue substitution.

## Checks

New `sim/` package. Substrate primitives proven on hand-built programs; tolerance counts pinned as an RNG regression and asserted to fall in the biological range. 16 sim tests pass, ridge and creatures suites still green, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)