### PR TITLE
Option 3 phase 3: evolutionary loop, and selection simplifies

### DIFF
--- a/sim/evolve.py
+++ b/sim/evolve.py
@@ -1,0 +1,78 @@
+""" evolve.py - mutation and selection over program genomes.
+
+The same plain loop as ridge.evolve, but the genome is now Python source and its
+fitness is the single-creature reproductive assay (sim.life). Selection sees only
+that score, which is survival and reproduction value, never a target program or
+behaviour. Nothing aims: the loop keeps whatever reproduces better and mutates
+it. Selecting on reproduction is not the rigged kind of goal (there is no target
+to match), it is the one pressure that exists in biology.
+
+Offspring mutation is whole-genome: with probability mutation_rate an offspring
+is a single mutation of its parent, otherwise an exact copy, matching the per-
+genome mutation framing used in Part A. Scores are cached by source, because a
+population is mostly identical copies.
+"""
+
+import dataclasses
+import random
+
+from sim import life, substrate
+
+
+@dataclasses.dataclass
+class Result:
+    """ What one run produced. """
+    best_source: str
+    best_score: int
+    history: list
+    generations: int
+
+
+def _tournament(population, scores, rng, size=3):
+    """ :return: The fitter of a few random genomes (the source itself) """
+    best = rng.randrange(len(population))
+    for _ in range(size - 1):
+        challenger = rng.randrange(len(population))
+        if scores[challenger] > scores[best]:
+            best = challenger
+    return population[best]
+
+
+def run(*, population_size, generations, mutation_rate, seed,
+        ancestor=substrate.ANCESTOR):
+    """ Evolves a population of programs under reproductive selection.
+    :param population_size: How many programs per generation
+    :param generations: How many generations to run
+    :param mutation_rate: Probability an offspring is mutated rather than copied
+    :param seed: Random seed; the same seed reproduces the run
+    :param ancestor: The founding program every genome starts as
+    :return: A Result, whose history is the best score in each generation
+        including the founding one
+    """
+    rng = random.Random(seed)
+    cache = {}
+
+    def score(source):
+        if source not in cache:
+            cache[source] = life.reproductive_output(source)
+        return cache[source]
+
+    population = [ancestor] * population_size
+    scores = [score(source) for source in population]
+    history = [max(scores)]
+
+    for _ in range(generations):
+        offspring = []
+        for _ in range(population_size):
+            parent = _tournament(population, scores, rng)
+            if rng.random() < mutation_rate:
+                offspring.append(substrate.mutate_once(parent, rng.randrange(2 ** 32)))
+            else:
+                offspring.append(parent)
+        population = offspring
+        scores = [score(source) for source in population]
+        history.append(max(scores))
+
+    best = max(range(population_size), key=lambda index: scores[index])
+    return Result(best_source=population[best], best_score=scores[best],
+                  history=history, generations=generations)

--- a/sim/test_evolve.py
+++ b/sim/test_evolve.py
@@ -1,0 +1,50 @@
+"""Tests for the program-substrate evolutionary loop.
+
+The pinned scores depend on the assay and the mutation RNG, so they are a
+reproducibility regression. The claims that matter: the loop is deterministic,
+selection raises reproductive output, and with no mutation nothing changes.
+"""
+
+import unittest
+
+from sim import evolve, life, substrate
+
+
+class TestEvolution(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.result = evolve.run(population_size=50, generations=40,
+                                mutation_rate=0.3, seed=0)
+
+    def test_history_covers_founder_plus_each_generation(self):
+        self.assertEqual(41, len(self.result.history))
+
+    def test_starts_at_the_ancestor_score(self):
+        self.assertEqual(life.reproductive_output(substrate.ANCESTOR),
+                         self.result.history[0])
+
+    def test_selection_raises_reproductive_output(self):
+        self.assertGreater(self.result.best_score, self.result.history[0])
+
+    def test_reaches_the_fertile_window_ceiling(self):
+        self.assertEqual(29, self.result.best_score)
+
+    def test_is_deterministic(self):
+        again = evolve.run(population_size=50, generations=40,
+                           mutation_rate=0.3, seed=0)
+        self.assertEqual(self.result.history, again.history)
+        self.assertEqual(self.result.best_source, again.best_source)
+
+
+class TestNoMutation(unittest.TestCase):
+
+    def test_without_mutation_nothing_changes(self):
+        result = evolve.run(population_size=20, generations=10,
+                            mutation_rate=0.0, seed=1)
+        self.assertEqual(result.best_source, substrate.ANCESTOR)
+        self.assertEqual(set(result.history), {result.history[0]})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

The program-substrate evolutionary loop: the plain mutation-and-selection loop from `ridge.evolve`, now over Python program genomes with the single-creature reproductive assay (`sim.life`) as fitness. Selection sees only reproductive output, never a target program, so it is the one pressure that exists in biology, not a rigged goal. Whole-genome mutation, tournament selection, deterministic, scores cached by source.

## It works, and it climbs

A population founded on the ancestor rises from **15 to the fertile-window ceiling of 29** offspring, reproducibly.

## But *how* it climbs is the finding

The single adaptive change the run discovers is `'endowment'` -> `'nndowment'`: a one-character typo that breaks the endowment dictionary key, so a creature gives its offspring nothing and hoards all its fuel. **The adaptation is a loss of function.**

In this simple solo environment, parental investment is pure cost, because offspring are not simulated, so cumulative selection optimises by *breaking* the one non-trivial feature the ancestor had, rather than building anything. That is not a bug to fix; it is the central Phase 3 result in miniature:

> Functional complexity accumulates only when the environment rewards it. A static, simple environment drives selection toward a trivial optimum, often by simplification.

The scaling sweep therefore cannot use this solo assay unchanged: it needs an environment where complexity actually pays (for example, offspring survival depending on endowment) before it can honestly ask whether evolution *builds* complexity. This PR surfaces that requirement with evidence rather than assuming it.

## Scope

Still ahead in Phase 3: an environment where complexity is adaptive; the functional-information measurement (with its random-program reference and sampling-ceiling caveat); the resource scaling sweep.

## Checks

30 sim tests pass, pylint 10.00/10. Deterministic; pinned scores are a reproducibility regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)