### PR TITLE
Protocell slice 1: a pool-of-functions cell that lives and divides

### DIFF
--- a/protocell/PLAN.md
+++ b/protocell/PLAN.md
@@ -1,0 +1,101 @@
+# Protocell: plan and honesty rules
+
+A more faithful evolution simulation than the `sim/` model, whose fatal flaw was
+that one character mutation changed one number that stood for an entire
+biological system (a 1:1 mutation-to-system ratio). Here a creature is a **pool
+of functions** ("proteins"), each doing real multi-step work, called
+stochastically to run a little cell. Mutation acts on the functions, so a single
+mutation is a small change to a multi-part system, closer to a point mutation in
+a gene.
+
+This file is committed **before** the simulation is trusted, as a guard against
+moving the goalposts. If a result later contradicts a claim here, the claim
+loses.
+
+## The one question everything serves
+
+**Under mutation and selection, does the functional (specified) information in a
+cell's protein pool go UP or DOWN, and how does that depend on the knobs we had
+to choose?**
+
+This is a *direction*, not a verdict. It can register increase (building) or
+decrease (degradation / genetic entropy) as a real result. No simulation can
+honestly deliver a universal "evolution can/can't build complexity"; any such
+claim just reflects substrate choices. We report the direction and its
+dependence on the knobs.
+
+Specified information here means the amount of the pool that is **constrained by
+function**: positions where a mutation reduces fitness. Random text has high
+Shannon entropy but low specified information; we measure the latter, by mutation
+sensitivity. This is the same functional-information idea used on real proteins
+in the `ridge/` work.
+
+## The model
+
+- **Protein**: a Python function, given as source, that reads and writes cell
+  state and the environment. A mutation that stops it running is a *misfolded*
+  protein: nonfunctional, cleared by turnover. (Measured earlier: raw
+  function-source mutation tolerates ~10% of single mutations, inside biology's
+  6-34%, so this is a defensible robustness level without a genetic-code layer.)
+- **Cell**: a pool of proteins plus energy and internal registers. Each tick,
+  proteins execute in random order and their combined effect keeps the cell
+  alive (metabolism) or divides it (reproduction). Proteins have lifespans;
+  old ones are cleared.
+- **World**: a finite, regrowing food pool the cells compete for. Selection is
+  emergent, survive and divide, nothing hand-picked.
+- **Mutation** (on division): the empirically **observed** spectrum, point
+  substitutions, small insertions/deletions, and whole-protein duplication and
+  deletion, at roughly observed relative rates. Observed, not inferred from
+  phylogeny.
+
+## Two seeds, to measure both directions
+
+- **Minimal seed**: a pool too poor to sustain the cell. Does mutation +
+  selection build it up (functional information rises)?
+- **Working seed**: a hand-written pool that lives and divides. Does it hold, or
+  degrade (functional information falls)?
+
+## Honesty rules (bias guards)
+
+1. **Generic primitives only.** Proteins are built from generic operations
+   (arithmetic, logic, read/write state, eat, divide). No task-specific freebie
+   like a `provision_offspring` primitive.
+2. **No fine-grained chooser.** Proteins are called stochastically. We never add
+   a "use whichever protein/copy works best" dispatcher; that would be us doing
+   selection. Selection happens only at the level of which cells survive and
+   divide.
+3. **Calibrate what we can to measured numbers.** Mutation tolerance to the
+   ~6-34% from real proteins; mutation spectrum to observed rates.
+4. **State every contrivance.** The cell inherits its core execution machinery
+   (there is no from-scratch ribosome); we evolve the workload proteins. Said in
+   the open.
+5. **Report direction and dependence, not a verdict.**
+6. **Readable, not just measurable.** Every run can dump its proteins as source,
+   so a layperson can *see* what changed, not only trust a number.
+
+## Vertical slices (thin, each tests an assumption)
+
+- **Slice 1 (this PR): can a stochastically-called protein pool run a living,
+  dividing cell at all?** Hand-written working pool vs a minimal one. No mutation
+  yet. Feedback: does the pool-of-functions substrate host life, and what must a
+  protein be able to do? Validates the substrate before evolution.
+- **Slice 2**: mutation on division (the observed spectrum); run a population;
+  the two seeds. Feedback: does minimal ever bootstrap; does working degrade.
+- **Slice 3**: the metrics, functional/specified information direction, pool
+  complexity, per-generation source dump.
+- **Slice 4+**: protein complexes (proteins combining into machinery), and the
+  knob-dependence study; then lit-check for prior art before any write-up.
+
+## Prior-art / publishability
+
+Digital evolution is a crowded field (Avida, Tierra, and their critiques). We do
+NOT assume this is novel. Before any write-up we lit-check specifically for: the
+functional-information-direction readout on a protein-pool cell with an observed
+mutation spectrum. If it is prior art, the value is a clean teaching artifact,
+not a paper. We decide that on evidence, later.
+
+## Revisable assumptions (expect slice feedback to change these)
+
+The protein/cell API, the primitive set, energy/cost/threshold parameters, and
+the mutation rates are all first guesses, to be adjusted as the slices tell us
+what the substrate actually needs.

--- a/protocell/ancestors.py
+++ b/protocell/ancestors.py
@@ -1,0 +1,41 @@
+""" ancestors.py - the two starting pools.
+
+Two seeds, so we can later watch both directions. The working pool lives and
+divides; the question for it is whether it degrades. The minimal pool cannot feed
+itself and dies; the question for it is whether anything ever builds it up.
+
+The proteins are deliberately plain and readable. They use only the generic cell
+API (eat, divide, energy, registers), nothing task-specific.
+"""
+
+from protocell.protein import Protein
+
+# Eat from the environment, more when low on energy; a crude metabolism.
+_METABOLISM = '''
+def protein(cell, env):
+    hunger = 40 - cell.energy
+    cell.eat(env, 3 + max(0, hunger) // 4)
+'''
+
+# Divide once there is energy to spare.
+_DIVISION = '''
+def protein(cell, env):
+    if cell.energy > 30:
+        cell.divide()
+'''
+
+# Does nothing useful: the cell that carries only this cannot feed and starves.
+_INERT = '''
+def protein(cell, env):
+    cell.registers[0] = cell.registers[0]
+'''
+
+
+def working_pool():
+    """ :return: A pool that sustains and divides a cell """
+    return [Protein(_METABOLISM), Protein(_DIVISION)]
+
+
+def minimal_pool():
+    """ :return: A pool too poor to keep a cell alive """
+    return [Protein(_INERT)]

--- a/protocell/cell.py
+++ b/protocell/cell.py
@@ -1,0 +1,80 @@
+""" cell.py - a cell run by a pool of proteins.
+
+The cell owns state a protein cannot mutate away: its energy, its age, and the
+rules of metabolism and death. The proteins own behaviour: each tick they run in
+random order and their combined effect feeds the cell and decides whether it
+divides. This split matters for the same reason it did in the creatures work: if
+proteins owned the death rules, evolution would delete them.
+
+The API a protein may call is small and generic: read `energy` and `registers`,
+`eat` food from the environment, write `registers`, and `divide`. A protein
+cannot set its own energy or cancel its own death directly.
+"""
+
+STARTING_ENERGY = 20
+MAX_ENERGY = 60
+METABOLIC_COST = 1
+MAX_AGE = 60
+DIVISION_THRESHOLD = 25
+DIVISION_COST = 10
+REGISTERS = 4
+
+
+class Cell:
+    """ A living cell: a protein pool plus engine-owned state. """
+
+    def __init__(self, proteins, *, energy=STARTING_ENERGY):
+        self.proteins = list(proteins)
+        self.energy = energy
+        self.age = 0
+        self.alive = True
+        self.registers = [0] * REGISTERS
+        self._wants_division = False
+
+    # --- API proteins may call ---
+
+    def eat(self, env, amount):
+        """ Takes up to `amount` food from the environment, turning it to energy.
+        :return: Energy actually gained
+        """
+        wanted = max(0, int(amount))
+        gained = env.request(min(wanted, MAX_ENERGY - self.energy))
+        self.energy += gained
+        return gained
+
+    def divide(self):
+        """ Requests division; granted after the tick if energy allows. """
+        self._wants_division = True
+
+    # --- engine-owned, proteins cannot reach these ---
+
+    def metabolize(self):
+        """ Pays the per-tick energy cost, ages, and checks for death. """
+        self.energy -= METABOLIC_COST
+        self.age += 1
+        if self.energy <= 0 or self.age >= MAX_AGE:
+            self.alive = False
+
+    def spawn_daughter(self, mutate=None):
+        """ If division was requested and affordable, produces a daughter.
+
+            The daughter inherits a copy of the pool (optionally mutated) and an
+            endowment of energy, both paid for by the parent.
+        :param mutate: Optional callable from a protein list to a new one
+        :return: A new Cell, or None
+        """
+        if not (self._wants_division and self.energy > DIVISION_THRESHOLD):
+            self._wants_division = False
+            return None
+        self._wants_division = False
+        self.energy -= DIVISION_COST
+        endowment = self.energy // 2
+        self.energy -= endowment
+        proteins = list(self.proteins)
+        if mutate is not None:
+            proteins = mutate(proteins)
+        return Cell(proteins, energy=endowment)
+
+    def dump(self):
+        """ :return: The pool as readable source, so a run can be inspected """
+        return '\n'.join(protein.source.strip() for protein in self.proteins)

--- a/protocell/protein.py
+++ b/protocell/protein.py
@@ -1,0 +1,56 @@
+""" protein.py - one protein: a function that acts on a cell.
+
+A protein is Python source defining `protein(cell, env)`. It reads and writes the
+cell's state (energy, registers) and the environment (food), the way a real
+protein reads and changes the chemistry around it. What it can do is deliberately
+generic: eat, divide, and compute with the cell's registers. Nothing task-
+specific is handed to it.
+
+A protein that cannot be compiled, or does not define `protein`, is *misfolded*:
+it is inert and never runs. A protein that raises while running simply has no
+effect that tick, the way a protein can fail on some substrates and not others.
+Neither can crash the cell, so mutation is survivable at the pool level.
+"""
+
+import ast
+import contextlib
+import io
+
+
+class Protein:  # pylint: disable=too-few-public-methods
+    """ A callable built from source, or inert if the source does not fold. """
+
+    def __init__(self, source):
+        self.source = source
+        self._function = None
+        self.folded = self._fold()
+
+    def _fold(self):
+        """ Compiles the source once. :return: True if it yields protein() """
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                namespace = {}
+                exec(compile(ast.parse(self.source), '<protein>', 'exec'),  # pylint: disable=exec-used
+                     namespace)
+        except Exception:  # pylint: disable=broad-except
+            return False
+        function = namespace.get('protein')
+        if not callable(function):
+            return False
+        self._function = function
+        return True
+
+    def execute(self, cell, env):
+        """ Runs the protein on a cell and environment.
+
+            A misfolded protein does nothing. A runtime error is swallowed: the
+            protein simply had no effect this tick.
+        :return: None
+        """
+        if not self.folded:
+            return
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self._function(cell, env)
+        except Exception:  # pylint: disable=broad-except
+            pass

--- a/protocell/run.py
+++ b/protocell/run.py
@@ -1,0 +1,34 @@
+""" run.py - watch a protocell population live, and read its genome.
+
+Slice 1: no mutation yet, just proof that a pool of stochastically-called
+functions runs a living, dividing cell, and that a pool too poor to feed itself
+dies. The whole "genome" is printed as source, so you can see exactly what the
+cell is, not just a number.
+
+Run: python -m protocell.run
+"""
+
+import sys
+
+from protocell import ancestors, world
+
+
+def main():
+    """ Prints a working run and a minimal (dying) run. """
+    working = world.run(ancestors.working_pool(), founders=10, ticks=120, seed=0)
+    print('WORKING pool: a cell run by a pool of stochastically-called proteins.')
+    print(f'  population over time (every 10 ticks): {working.history[::10]}')
+    print(f'  survivors: {len(working.survivors)}   divisions: {working.generations}')
+    print('  the whole genome of a survivor, readable:')
+    for line in working.survivors[0].dump().splitlines():
+        print(f'    {line}')
+    print()
+    minimal = world.run(ancestors.minimal_pool(), founders=10, ticks=120, seed=0)
+    print('MINIMAL pool: cannot feed itself.')
+    print(f'  population over time (every 10 ticks): {minimal.history[::10]}')
+    print(f'  extinct: {minimal.extinct}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/protocell/test_cell.py
+++ b/protocell/test_cell.py
@@ -1,0 +1,62 @@
+"""Tests for the cell, the engine-owned state a protein cannot mutate away."""
+
+import unittest
+
+from creatures import lifecycle
+from protocell import cell as cell_module
+from protocell.ancestors import working_pool
+from protocell.cell import Cell
+
+
+class TestProteinApi(unittest.TestCase):
+
+    def test_eat_turns_food_into_energy(self):
+        cell = Cell([], energy=10)
+        gained = cell.eat(lifecycle.World(food=100, regrowth=0), 5)
+        self.assertEqual(5, gained)
+        self.assertEqual(15, cell.energy)
+
+    def test_eat_is_capped_by_the_energy_ceiling(self):
+        cell = Cell([], energy=cell_module.MAX_ENERGY - 2)
+        self.assertEqual(2, cell.eat(lifecycle.World(food=100, regrowth=0), 50))
+
+    def test_eat_is_limited_by_available_food(self):
+        cell = Cell([], energy=10)
+        self.assertEqual(3, cell.eat(lifecycle.World(food=3, regrowth=0), 50))
+
+
+class TestEngineOwnedRules(unittest.TestCase):
+
+    def test_metabolize_costs_energy_and_ages(self):
+        cell = Cell([], energy=5)
+        cell.metabolize()
+        self.assertEqual(5 - cell_module.METABOLIC_COST, cell.energy)
+        self.assertEqual(1, cell.age)
+
+    def test_starvation_kills(self):
+        cell = Cell([], energy=cell_module.METABOLIC_COST)
+        cell.metabolize()
+        self.assertFalse(cell.alive)
+
+    def test_no_division_without_a_request(self):
+        self.assertIsNone(Cell([], energy=50).spawn_daughter())
+
+    def test_division_produces_a_daughter_when_rich(self):
+        cell = Cell(working_pool(), energy=50)
+        cell.divide()
+        daughter = cell.spawn_daughter()
+        self.assertIsNotNone(daughter)
+        self.assertGreater(daughter.energy, 0)
+        self.assertLess(cell.energy, 50)  # the parent paid for it
+
+    def test_division_denied_when_too_poor(self):
+        cell = Cell(working_pool(), energy=cell_module.DIVISION_THRESHOLD)
+        cell.divide()
+        self.assertIsNone(cell.spawn_daughter())
+
+    def test_dump_is_readable_source(self):
+        self.assertIn('def protein', Cell(working_pool()).dump())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/protocell/test_protein.py
+++ b/protocell/test_protein.py
@@ -1,0 +1,41 @@
+"""Tests for a single protein."""
+
+import unittest
+
+from protocell.cell import Cell
+from protocell.protein import Protein
+
+WRITES_REGISTER = 'def protein(cell, env):\n    cell.registers[0] = 1\n'
+
+
+class TestFolding(unittest.TestCase):
+
+    def test_valid_source_folds(self):
+        self.assertTrue(Protein(WRITES_REGISTER).folded)
+
+    def test_a_syntax_error_misfolds(self):
+        self.assertFalse(Protein('def protein(').folded)
+
+    def test_source_without_protein_misfolds(self):
+        self.assertFalse(Protein('x = 1').folded)
+
+
+class TestExecution(unittest.TestCase):
+
+    def test_a_folded_protein_applies_its_effect(self):
+        cell = Cell([])
+        Protein(WRITES_REGISTER).execute(cell, None)
+        self.assertEqual(1, cell.registers[0])
+
+    def test_a_misfolded_protein_does_nothing(self):
+        cell = Cell([])
+        Protein('def protein(').execute(cell, None)  # must not raise
+        self.assertEqual(0, cell.registers[0])
+
+    def test_a_runtime_error_is_swallowed(self):
+        crashes = 'def protein(cell, env):\n    raise ValueError("boom")\n'
+        Protein(crashes).execute(Cell([]), None)  # must not raise
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/protocell/test_world.py
+++ b/protocell/test_world.py
@@ -1,0 +1,39 @@
+"""Tests for the population run, slice 1's assumption check.
+
+The point of this slice: a pool of stochastically-called functions can host a
+living, dividing, competing population, and a pool too poor to feed itself dies.
+No mutation yet.
+"""
+
+import unittest
+
+from protocell import ancestors, world
+
+
+class TestWorld(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.working = world.run(ancestors.working_pool(), founders=10,
+                                ticks=120, seed=0)
+
+    def test_the_working_pool_sustains_a_population(self):
+        self.assertFalse(self.working.extinct)
+        self.assertGreater(max(self.working.history), 10)  # it grew past the founders
+
+    def test_the_working_run_is_pinned(self):
+        self.assertEqual(44, len(self.working.survivors))
+        self.assertEqual(120, self.working.generations)
+
+    def test_a_pool_that_cannot_feed_goes_extinct(self):
+        result = world.run(ancestors.minimal_pool(), founders=10, ticks=120, seed=0)
+        self.assertTrue(result.extinct)
+
+    def test_a_run_is_deterministic(self):
+        first = world.run(ancestors.working_pool(), founders=10, ticks=60, seed=1)
+        second = world.run(ancestors.working_pool(), founders=10, ticks=60, seed=1)
+        self.assertEqual(first.history, second.history)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/protocell/world.py
+++ b/protocell/world.py
@@ -1,0 +1,79 @@
+""" world.py - a population of cells competing for finite food.
+
+Runs many cells against one regrowing food pool. Each tick every living cell
+executes its proteins in random order, pays its metabolic cost, and may divide;
+daughters join the population. Cells that starve or age out are removed. Nothing
+is selected by hand: cells that feed and divide leave more descendants, cells
+that do not die out. That is the whole of the selection.
+"""
+
+import dataclasses
+import random
+
+from creatures import lifecycle
+from protocell.cell import Cell
+
+DEFAULT_FOOD = 200
+DEFAULT_REGROWTH = 60
+
+
+@dataclasses.dataclass
+class Result:
+    """ What one run produced. """
+    history: list          # population size at each tick, including the start
+    survivors: list        # the living cells at the end
+    generations: int       # how many divisions happened in total
+
+    @property
+    def extinct(self):
+        """ :return: True if the population died out """
+        return not self.survivors
+
+
+def _step(population, env, rng, mutate):
+    """ Runs one tick: everyone acts, metabolizes, and maybe divides.
+    :return: (the next population, number of daughters born)
+    """
+    env.tick()
+    rng.shuffle(population)
+    daughters = []
+    for cell in population:
+        if not cell.alive:
+            continue
+        order = list(cell.proteins)
+        rng.shuffle(order)
+        for protein in order:
+            protein.execute(cell, env)
+        cell.metabolize()
+        daughter = cell.spawn_daughter(mutate=mutate)
+        if daughter is not None:
+            daughters.append(daughter)
+    return [cell for cell in population if cell.alive] + daughters, len(daughters)
+
+
+# Seven knobs, all keyword-only run parameters; bundling them would only hide
+# what a run is.
+def run(founder_pool, *, founders=10, ticks=200,  # pylint: disable=too-many-arguments
+        food=DEFAULT_FOOD, regrowth=DEFAULT_REGROWTH, seed=0, mutate=None):
+    """ Runs a population from a founder protein pool.
+    :param founder_pool: A list of Proteins every founder starts with
+    :param founders: How many founder cells
+    :param ticks: How many ticks to run
+    :param food: Starting food in the shared pool
+    :param regrowth: Food added each tick
+    :param seed: Random seed; the same seed reproduces the run
+    :param mutate: Optional callable applied to a daughter's protein list
+    :return: A Result
+    """
+    rng = random.Random(seed)
+    env = lifecycle.World(food=food, regrowth=regrowth)
+    population = [Cell(list(founder_pool)) for _ in range(founders)]
+    history = [len(population)]
+    divisions = 0
+    for _ in range(ticks):
+        population, born = _step(population, env, rng, mutate)
+        divisions += born
+        history.append(len(population))
+        if not population:
+            break
+    return Result(history=history, survivors=population, generations=divisions)


### PR DESCRIPTION
## What

The start of the more faithful substrate we designed, and the first thin vertical slice. `sim/`'s flaw was that one character mutation changed one number standing for an entire biological system. Here a creature is a **pool of functions** ("proteins"), each doing real multi-step work, called stochastically to run a little cell, so a mutation is a small change to a multi-part system rather than magic.

**`PLAN.md` is committed first, as the bias guard**, before the simulation is trusted:
- **The one question:** does the functional/specified information in a pool go **up or down** under mutation and selection? A direction, not a verdict, so it can register building *or* degradation.
- The model, the two seeds (minimal / working), and the honesty rules: generic primitives only, no fine-grained "use the best copy" chooser, calibrate to the measured ~6-34% mutation tolerance, use the *observed* mutation spectrum, state every contrivance, keep it readable.

## Slice 1: does the substrate host life at all?

Before pouring evolution on, test the riskiest assumption: can a stochastically-called protein pool run a living, dividing, competing population? It can.

- **Working pool** (a metabolism protein + a division protein): population grows 10 → ~50 and holds at the food-limited carrying capacity, 120 divisions, seeded and reproducible.
- **Minimal pool** (cannot feed itself): extinct by tick ~15.
- **You can read the whole genome.** `python -m protocell.run` prints the population curve *and* dumps a survivor's proteins as source.

No mutation yet, that's slice 2.

## Structure

- `protein.py` — a protein folds from source or misfolds gracefully; a runtime error just means "no effect this tick." Never crashes the cell.
- `cell.py` — engine-owned energy/metabolism/death a protein cannot mutate away; a small generic API (eat, divide, registers).
- `world.py` — a population on one finite food pool; selection is purely emergent.
- `ancestors.py` — the two seeds. `run.py` — watch it live and read its genome.

## Checks

19 tests, pylint 10.00/10.

## Next slices (from PLAN.md)

2: mutation on division (observed spectrum) + the two seeds; 3: the functional-information direction metric + per-generation source dump; 4+: protein complexes, knob-dependence, then a prior-art lit-check before any write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)