### PR TITLE
Protocell slice 2: observed-spectrum mutation, and what it reveals

### DIFF
--- a/protocell/PLAN.md
+++ b/protocell/PLAN.md
@@ -94,6 +94,23 @@ functional-information-direction readout on a protein-pool cell with an observed
 mutation spectrum. If it is prior art, the value is a clean teaching artifact,
 not a paper. We decide that on evidence, later.
 
+## Slice findings (a running log, so the record shows what we learned)
+
+- **Slice 1**: a stochastically-called protein pool hosts a living, dividing,
+  competing population; a pool that cannot feed dies. Substrate validated.
+- **Slice 2** (mutation, observed spectrum): three things surfaced.
+  1. The working pool tolerates observed-spectrum mutation and persists (no
+     meltdown at point rates 0.5-2.0 per division).
+  2. A non-reproducing seed cannot evolve at all: no feeding, no division, and
+     mutation only happens at division, so no variation is ever generated. The
+     build-test seed must reproduce. Added `crude_pool` for that.
+  3. The crude reproducing pool does NOT build better function: at a food-capped
+     carrying capacity a more efficient mutant does not out-reproduce, so there
+     is no selection gradient rewarding function. What accumulates is
+     duplication and degradation, not improvement. **Slice 3 needs an
+     environment that rewards function (a selection gradient), plus the
+     specified-information metric, before build-vs-degrade can be measured.**
+
 ## Revisable assumptions (expect slice feedback to change these)
 
 The protein/cell API, the primitive set, energy/cost/threshold parameters, and

--- a/protocell/ancestors.py
+++ b/protocell/ancestors.py
@@ -39,3 +39,19 @@ def working_pool():
 def minimal_pool():
     """ :return: A pool too poor to keep a cell alive """
     return [Protein(_INERT)]
+
+
+# Feeds and divides, so it reproduces (and can therefore evolve), but crudely:
+# a fixed intake with no response to hunger. The build-test seed, with headroom
+# above it for selection to find, if it can.
+_CRUDE = '''
+def protein(cell, env):
+    cell.eat(env, 4)
+    if cell.energy > 30:
+        cell.divide()
+'''
+
+
+def crude_pool():
+    """ :return: A reproducing but suboptimal pool, the seed for the build test """
+    return [Protein(_CRUDE)]

--- a/protocell/mutation.py
+++ b/protocell/mutation.py
@@ -1,0 +1,88 @@
+""" mutation.py - mutate a protein pool using the observed spectrum.
+
+The point-level spectrum is set to the directly observed human germline numbers,
+not anything inferred from phylogeny: roughly 92% single-character substitutions
+and 8% small insertions/deletions (the indel rate is ~10-15x below the
+substitution rate). Mutations act on the protein source text, so one mutation is
+a small change to a multi-step function, the granularity a point mutation has in
+a gene.
+
+Whole-protein duplication and deletion (the gene-duplication and gene-loss
+analogs) are, in the observed data, far rarer than point events (~0.03% of de
+novo mutations). We keep them as separately tunable knobs, deliberately elevated
+above that observed frequency so their effect can be studied at all, and we say
+so rather than hide it.
+
+The absolute per-division rate is a tunable knob and is scaled up from biology's
+per-base rate, because we cannot run biology's population sizes or timescales.
+What is calibrated to biology is the relative spectrum, not the absolute rate.
+"""
+
+import math
+import string
+
+from protocell.protein import Protein
+
+# Characters a substitution or insertion may introduce: enough of Python's
+# alphabet to explore code, matching the source the proteins are written in.
+ALPHABET = string.ascii_letters + string.digits + " ()[]{}:,.+-*/<>=%_'\n"
+
+# Observed germline point spectrum.
+SUBSTITUTION_SHARE = 0.92
+INSERTION_SHARE = 0.04  # the remaining 0.08 is split between the two indel types
+# (deletion is whatever is left)
+
+DEFAULT_POINT_LAMBDA = 1.0
+DEFAULT_DUPLICATION_RATE = 0.03
+DEFAULT_PROTEIN_DELETION_RATE = 0.03
+
+
+def _poisson(lam, rng):
+    """ :return: A Poisson(lam) sample using Knuth's method """
+    target = math.exp(-lam)
+    count, product = 0, 1.0
+    while True:
+        count += 1
+        product *= rng.random()
+        if product <= target:
+            return count - 1
+
+
+def _point_mutate(source, rng):
+    """ Applies one point event to source text, by the observed spectrum. """
+    if not source:
+        return rng.choice(ALPHABET)
+    position = rng.randrange(len(source))
+    roll = rng.random()
+    if roll < SUBSTITUTION_SHARE:
+        return source[:position] + rng.choice(ALPHABET) + source[position + 1:]
+    if roll < SUBSTITUTION_SHARE + INSERTION_SHARE:
+        return source[:position] + rng.choice(ALPHABET) + source[position:]
+    return source[:position] + source[position + 1:]
+
+
+def mutate(proteins, rng, *, point_lambda=DEFAULT_POINT_LAMBDA,
+           duplication_rate=DEFAULT_DUPLICATION_RATE,
+           protein_deletion_rate=DEFAULT_PROTEIN_DELETION_RATE):
+    """ Returns a mutated copy of a protein pool.
+
+        Structural events first (rare): a whole protein may be duplicated or
+        deleted. Then a Poisson-distributed number of point events, each a
+        substitution, insertion, or deletion in one protein's source at the
+        observed relative rates.
+    :param proteins: The parent pool (a list of Proteins)
+    :param rng: A random.Random, for reproducibility
+    :return: A new list of Proteins
+    """
+    pool = list(proteins)
+    if pool and rng.random() < duplication_rate:
+        index = rng.randrange(len(pool))
+        pool.insert(index, Protein(pool[index].source))
+    if len(pool) > 1 and rng.random() < protein_deletion_rate:
+        del pool[rng.randrange(len(pool))]
+    for _ in range(_poisson(point_lambda, rng)):
+        if not pool:
+            break
+        index = rng.randrange(len(pool))
+        pool[index] = Protein(_point_mutate(pool[index].source, rng))
+    return pool

--- a/protocell/protein.py
+++ b/protocell/protein.py
@@ -15,6 +15,7 @@ Neither can crash the cell, so mutation is survivable at the pool level.
 import ast
 import contextlib
 import io
+import warnings
 
 
 class Protein:  # pylint: disable=too-few-public-methods
@@ -28,7 +29,8 @@ class Protein:  # pylint: disable=too-few-public-methods
     def _fold(self):
         """ Compiles the source once. :return: True if it yields protein() """
         try:
-            with contextlib.redirect_stdout(io.StringIO()):
+            with contextlib.redirect_stdout(io.StringIO()), warnings.catch_warnings():
+                warnings.simplefilter('ignore')  # mutants routinely trip SyntaxWarning
                 namespace = {}
                 exec(compile(ast.parse(self.source), '<protein>', 'exec'),  # pylint: disable=exec-used
                      namespace)

--- a/protocell/run.py
+++ b/protocell/run.py
@@ -8,13 +8,26 @@ cell is, not just a number.
 Run: python -m protocell.run
 """
 
+import random
 import sys
 
-from protocell import ancestors, world
+from protocell import ancestors, mutation, world
+
+
+def _mutating_run():
+    """ Runs the crude reproducing pool under mutation, so the effect is visible. """
+    rng = random.Random(0)
+    result = world.run(ancestors.crude_pool(), founders=15, ticks=400, seed=0,
+                       mutate=lambda pool: mutation.mutate(pool, rng))
+    print('CRUDE pool WITH mutation (observed spectrum):')
+    print(f'  population over time (every 40 ticks): {result.history[::40]}')
+    print('  an evolved genome, note the accumulated duplication and junk:')
+    for line in result.survivors[0].dump().splitlines():
+        print(f'    {line}')
 
 
 def main():
-    """ Prints a working run and a minimal (dying) run. """
+    """ Prints a working run, a minimal (dying) run, and a mutating run. """
     working = world.run(ancestors.working_pool(), founders=10, ticks=120, seed=0)
     print('WORKING pool: a cell run by a pool of stochastically-called proteins.')
     print(f'  population over time (every 10 ticks): {working.history[::10]}')
@@ -27,6 +40,8 @@ def main():
     print('MINIMAL pool: cannot feed itself.')
     print(f'  population over time (every 10 ticks): {minimal.history[::10]}')
     print(f'  extinct: {minimal.extinct}')
+    print()
+    _mutating_run()
     return 0
 
 

--- a/protocell/test_mutation.py
+++ b/protocell/test_mutation.py
@@ -1,0 +1,67 @@
+"""Tests for the observed-spectrum mutation operators."""
+
+import random
+import unittest
+
+from protocell import mutation
+from protocell.protein import Protein
+
+SOURCE = 'def protein(cell, env):\n    cell.eat(env, 4)\n'
+
+
+class TestPointSpectrum(unittest.TestCase):
+
+    def test_point_events_follow_the_observed_shares(self):
+        # Substitutions keep length, insertions add one, deletions remove one.
+        rng = random.Random(0)
+        same = longer = shorter = 0
+        for _ in range(3000):
+            mutant = mutation._point_mutate(SOURCE, rng)  # pylint: disable=protected-access
+            if len(mutant) == len(SOURCE):
+                same += 1
+            elif len(mutant) == len(SOURCE) + 1:
+                longer += 1
+            else:
+                shorter += 1
+        # ~92% substitutions, the rest indels; assert substitution dominance.
+        self.assertGreater(same / 3000, 0.85)
+        self.assertGreater(longer, 0)
+        self.assertGreater(shorter, 0)
+
+    def test_point_mutation_of_empty_source_grows_it(self):
+        self.assertEqual(1, len(mutation._point_mutate('', random.Random(0))))  # pylint: disable=protected-access
+
+
+class TestMutate(unittest.TestCase):
+
+    def _pool(self):
+        return [Protein(SOURCE)]
+
+    def test_returns_proteins(self):
+        result = mutation.mutate(self._pool(), random.Random(1))
+        self.assertTrue(all(isinstance(protein, Protein) for protein in result))
+
+    def test_is_deterministic_for_a_seed(self):
+        first = mutation.mutate(self._pool(), random.Random(2))
+        second = mutation.mutate(self._pool(), random.Random(2))
+        self.assertEqual([p.source for p in first], [p.source for p in second])
+
+    def test_no_events_leaves_the_pool_unchanged(self):
+        result = mutation.mutate(self._pool(), random.Random(3), point_lambda=0.0,
+                                 duplication_rate=0.0, protein_deletion_rate=0.0)
+        self.assertEqual([SOURCE], [p.source for p in result])
+
+    def test_duplication_grows_the_pool(self):
+        result = mutation.mutate(self._pool(), random.Random(4), point_lambda=0.0,
+                                 duplication_rate=1.0, protein_deletion_rate=0.0)
+        self.assertEqual(2, len(result))
+
+    def test_protein_deletion_shrinks_the_pool(self):
+        pool = [Protein(SOURCE), Protein(SOURCE)]
+        result = mutation.mutate(pool, random.Random(5), point_lambda=0.0,
+                                 duplication_rate=0.0, protein_deletion_rate=1.0)
+        self.assertEqual(1, len(result))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Adds mutation on division, grounded in the **directly observed** human germline spectrum (trio sequencing, not phylogenetic inference, which matters for neutrality here): **~92% single-character substitutions, ~8% small indels**. Mutations act on protein source text, so one mutation is a small change to a multi-step function.

Whole-protein duplication and deletion (the gene-duplication and gene-loss analogs) are kept as **separately tunable knobs, disclosed as elevated** above their ~0.03% observed per-event frequency so their effect can be studied at all. The absolute per-division rate is a scaled, disclosed knob; the part calibrated to biology is the *relative spectrum*.

Sources for the spectrum: de novo SNV rate ~1.29×10⁻⁸/bp, indel rate ~10-15× lower, ~92% of de novo mutations are SNVs ([Nature 2025 pedigree reference](https://www.nature.com/articles/s41586-025-08922-2); [trio consensus study](https://www.life-science-alliance.org/content/8/6/e202403039)).

## What running both seeds revealed (logged in PLAN.md)

This slice is about feedback, not a result, and it surfaced three things:

1. **The working pool tolerates the mutation load and persists** (no meltdown at point rates 0.5-2.0 per division).
2. **A non-reproducing seed cannot evolve at all.** It can't feed, so it never divides, and mutation only happens at division, so no variation is ever generated. Correct biology (no replication, no evolution), but it means the build-test seed must reproduce. Added `crude_pool` for that.
3. **The crude reproducing pool does NOT build better function.** At a food-capped carrying capacity, a more-efficient mutant doesn't out-reproduce, so **there is no selection gradient rewarding function**. What accumulates instead is **duplication and degradation** (visible in `python -m protocell.run`), not improvement.

## Why this matters for the plan

Finding 3 tells slice 3 exactly what it needs before build-vs-degrade can be measured honestly: **an environment that actually rewards function (a selection gradient), plus the specified-information metric.** Measuring "did it build" in an environment with no pressure to build would have been meaningless. Better to catch it here.

**No scientific claim is made in this PR.** These are design feedbacks that shape the next slice, in keeping with the thin-slice plan.

## Checks

26 tests, pylint 10.00/10. `run.py` now shows a mutating run and dumps an evolved genome (visible duplication and junk), so the mutation effect is readable, not just numeric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)