### PR TITLE
K-axis slice 5: validate the engine against waiting-time math

### DIFF
--- a/kaxis/README.md
+++ b/kaxis/README.md
@@ -1,0 +1,70 @@
+# K-axis: buildability as a function of coordination number
+
+This package generalizes the protocell build/degrade question into a single
+controlled experiment, and grounds it against mainstream population genetics
+before making any claim.
+
+## The one control variable
+
+The protocell work established a distinction that matters: **tuning** an existing
+function (a gradient exists, and evolution climbs it easily) is not the same as
+**creating** a new coordinated structure (where nothing works until several
+specific things are simultaneously right). The disagreement in the field is not
+about tuning; it is about creation, and specifically about whether the fitness
+landscape supplies a gradient of functional intermediates or not.
+
+So we make that the knob. **K** is the coordination number: how many specific
+things must be simultaneously right before *any* reward exists.
+
+- **K = 1** is pure tuning. A gradient is present everywhere; structure is built
+  easily.
+- **K large** is irreducible: no functional intermediate, so selection is blind
+  to progress and only mutation supply and neutral drift can cross the gap.
+- **Selection strength** is a second dial. Turn it to zero and there is no
+  differential reproduction at all, which is the **origin-of-replicator** limit,
+  where "no gradient" is a logical necessity rather than a modeling choice.
+
+The two questions the author cares about, de novo origin of coordinated function
+and the origin of the replicator, are therefore two settings of one apparatus,
+not two models.
+
+## Honesty rules (bias guards, committed before results are trusted)
+
+1. **No authored intermediate rewards.** Selection sees only whole-organism
+   survival and reproduction. We never hand-pay a half-built structure to lead it
+   toward the goal; injecting a gradient is injecting the conclusion. If we study
+   how a gradient changes buildability, the gradient is an explicit, reported
+   variable, never a hidden default.
+2. **Neutral intermediates are the honest hard case**, and the default.
+3. **Validate the engine against mainstream math before using it.** We do not get
+   to claim "evolution cannot build this" on an engine no population geneticist
+   would accept. Slice 5 does this validation first.
+4. **Report buildability as a function of K and selection strength**, a curve,
+   never a single universal verdict. Where real biology sits on the K-axis is a
+   separate empirical question we do not prejudge.
+
+## Slice 5 (this PR): the engine is trustworthy
+
+A minimal Wright-Fisher engine (population.py) for a K-step structure with
+neutral intermediates, checked against the analytic waiting time (analytic.py):
+
+- **K = 1**: reproduces the exact geometric appearance time (ratio 0.997).
+- **K = 2**: reproduces the Durrett-Schmidt drift-assisted law. Cutting the
+  second mutation rate by 16 lengthens the wait by about sqrt(16) = 4, not by 16.
+  The slope of log(wait) vs log(u2) is -0.56, the square-root law, not the naive
+  -1. See data/waiting_validation.txt.
+
+Because the engine matches the waiting time a population geneticist would compute,
+it cannot be dismissed as rigged. That is the foundation the later buildability(K)
+slices stand on. Run it: `python -m kaxis.validate`.
+
+## Next slices
+
+- **Slice 6**: sweep K under honest whole-organism selection and read off
+  buildability(K), with selection strength as the second dial (origin-of-
+  replicator = the large-K, selection-off corner).
+- **Then**: place real biology on the K-axis using measured data (the ridge/ DMS
+  landscapes for the low-K tuning end; de novo function frequencies such as
+  Keefe and Szostak's 37-bit ATP binders for the "how rare is function at all"
+  end), and lit-check (Avida, Tierra, and the waiting-time literature) before any
+  write-up.

--- a/kaxis/analytic.py
+++ b/kaxis/analytic.py
@@ -1,0 +1,32 @@
+""" analytic.py - the mainstream waiting-time predictions we validate against.
+
+These are the referee. The simulation in population.py is only trusted to the
+extent it reproduces these closed forms for the same model.
+
+  - one_step_wait: with a single step, first appearance is geometric in the
+    per-generation success probability across the whole population. This is exact,
+    so it is the sharp unit test on the engine's mutation supply and timing.
+
+  - two_step_wait: Durrett and Schmidt (2008), "Waiting for Two Mutations",
+    Genetics 180:1501. With a NEUTRAL intermediate, the mean wait for both steps
+    in one lineage is about 1 / (2 N u1 sqrt(u2)). The square root is the whole
+    result: a neutral intermediate can drift to modest frequency and give the
+    second step many more chances than a "both at once" model would allow, so the
+    wait grows like 1/sqrt(u2), not 1/u2. Valid when u2 << 1/N.
+"""
+
+import math
+
+
+def one_step_wait(pop_size, rate):
+    """ :return: Exact mean generations to the first single-step genome. """
+    appearance_prob = 1.0 - (1.0 - rate) ** pop_size
+    return 1.0 / appearance_prob
+
+
+def two_step_wait(pop_size, rate1, rate2):
+    """ :return: Durrett-Schmidt mean wait for two steps, neutral intermediate.
+
+    Approximation; assumes rate2 << 1 / pop_size (the drift-assisted regime).
+    """
+    return 1.0 / (2.0 * pop_size * rate1 * math.sqrt(rate2))

--- a/kaxis/data/waiting_validation.txt
+++ b/kaxis/data/waiting_validation.txt
@@ -1,0 +1,44 @@
+K-axis slice 5: waiting-time validation of the Wright-Fisher engine.
+
+Recorded here because the fuller two-step slope run is slow (about two minutes).
+The fast subset is checked on every test run (kaxis/test_population.py) and by
+kaxis/validate.py; this file is the fuller record, including the log-log slope.
+
+Model: population.py. A constant population must complete K sequential steps;
+every intermediate is selectively NEUTRAL; only the finished K-step genome is
+recorded, at first appearance. Referee: analytic.py.
+
+One step (exact geometric appearance time), N=1000, u1=3.36e-5, 4000 replicates:
+  simulated = 30.188   analytic = 30.264   ratio = 0.9975
+  The engine's mutation supply and timing are exact.
+
+Two steps (neutral intermediate), N=1000, u1=1e-3, 400 replicates per point:
+  u2 = 1.0e-06:  simulated = 1680.2   analytic (D-S) = 500.0   ratio = 3.36
+  u2 = 4.0e-06:  simulated =  834.7   analytic (D-S) = 250.0   ratio = 3.34
+  u2 = 1.6e-05:  simulated =  355.7   analytic (D-S) = 125.0   ratio = 2.85
+  slope of log(mean wait) vs log(u2) = -0.560
+
+Reading:
+  - The slope is -0.56, i.e. the wait grows like u2^(-1/2), the Durrett-Schmidt
+    drift-assisted law, NOT the naive u2^(-1) "both mutations at once" law
+    (which would give slope -1). A neutral intermediate drifts to modest
+    frequency and gives the second step many extra chances.
+  - The absolute prefactor sits a stable ~3x above the Durrett-Schmidt formula.
+    That constant is expected: their 1/(2 N u1 sqrt(u2)) is an as-u2->0
+    asymptotic with an order-1 constant, and the ratio is roughly flat across
+    u2, which is the mark of a matched scaling law with an offset constant.
+    We validate the scaling, not the constant.
+
+Conclusion: the engine reproduces mainstream population-genetics waiting times,
+including the nontrivial square-root law, so it is trusted to measure
+buildability(K) in later slices. No one can call it rigged: it agrees with the
+math a population geneticist would use.
+
+Reproduce (about two minutes):
+  import math
+  from kaxis import population, analytic
+  N, u1 = 1000, 1e-3
+  for u2 in (1e-6, 4e-6, 1.6e-5):
+      m = population.mean_waiting_time(N, (u1, u2), replicates=400, seed=7)
+      print(u2, m, analytic.two_step_wait(N, u1, u2), m / analytic.two_step_wait(N, u1, u2))
+  # fit slope of log(m) vs log(u2): expect about -0.5

--- a/kaxis/population.py
+++ b/kaxis/population.py
@@ -1,0 +1,118 @@
+""" population.py - a minimal Wright-Fisher engine for the K-step waiting time.
+
+The credibility foundation for the whole K-axis apparatus. Before we ever claim
+something about how hard it is to build a coordinated K-part structure, we have
+to show our evolutionary engine reproduces the waiting time that mainstream
+population genetics predicts for the same model. If it does, no one can call the
+engine rigged; if it does not, the engine is wrong and we fix it before going on.
+
+The model is deliberately bare:
+
+  - A constant population of `pop_size` asexual replicators.
+  - A genome that must complete K sequential steps. `rates[i]` is the
+    per-individual per-generation probability of advancing from step i to i+1.
+  - Every intermediate (0..K-1 steps done) is selectively NEUTRAL. Only the
+    finished K-step genome is "the structure"; we time its first appearance.
+  - No back mutation, no recombination.
+
+Neutral intermediates are the honest, hard case: nothing rewards a half-built
+structure, so selection is blind to the intermediates and the only forces are
+mutation supply and neutral drift. That is exactly the regime Durrett and Schmidt
+(2008) solved analytically, which is our referee in analytic.py.
+
+Sampling is pure-stdlib `random` for determinism, matching the rest of the repo.
+Both the mutation step and the drift resample act only on rare classes (the
+intermediates are always a small minority in this regime), so a geometric-gap
+binomial sampler keeps every draw fast.
+"""
+
+import math
+import random
+
+DEFAULT_MAX_GENERATIONS = 10 ** 8
+
+
+def _binomial(trials, prob, rng):
+    """ :return: An exact Binomial(trials, prob) draw via geometric gap skipping.
+
+    Fast when prob is small (the regime here), because it steps from one success
+    to the next rather than testing every trial.
+    """
+    if trials <= 0 or prob <= 0.0:
+        return 0
+    if prob >= 1.0:
+        return trials
+    log_q = math.log1p(-prob)
+    count = 0
+    index = -1
+    while True:
+        gap = int(math.log(1.0 - rng.random()) / log_q)
+        index += gap + 1
+        if index >= trials:
+            return count
+        count += 1
+
+
+def _advance(counts, rates, rng):
+    """ :return: New class counts after one generation of mutation.
+
+    Processed from the last step down so a genome advances at most one step per
+    generation, matching a low-rate continuous-time process.
+    """
+    new = list(counts)
+    for step in range(len(rates) - 1, -1, -1):
+        movers = _binomial(new[step], rates[step], rng)
+        new[step] -= movers
+        new[step + 1] += movers
+    return new
+
+
+def _drift(counts, pop_size, rng):
+    """ :return: New class counts after one neutral Wright-Fisher resample.
+
+    Drawn as conditional binomials over the rare intermediate classes; the
+    ground state (step 0) takes the remainder, so every binomial draw has a small
+    probability and stays fast.
+    """
+    new = [0] * len(counts)
+    remaining = pop_size
+    prob_remaining = 1.0
+    for step in range(len(counts) - 1, 0, -1):
+        if counts[step] == 0:
+            continue
+        prob = counts[step] / pop_size
+        drawn = _binomial(remaining, prob / prob_remaining, rng)
+        new[step] = drawn
+        remaining -= drawn
+        prob_remaining -= prob
+    new[0] = remaining
+    return new
+
+
+def waiting_time(pop_size, rates, rng, *, max_generations=DEFAULT_MAX_GENERATIONS):
+    """ :return: Generations until the first genome completes all K steps.
+
+    K is len(rates). Appearance is recorded right after the mutation step, before
+    drift can lose it, matching "time until some individual has experienced all
+    the mutations."
+    """
+    completed = len(rates)
+    counts = [pop_size] + [0] * completed
+    generation = 0
+    while generation < max_generations:
+        generation += 1
+        counts = _advance(counts, rates, rng)
+        if counts[completed] >= 1:
+            return generation
+        counts = _drift(counts, pop_size, rng)
+    return generation
+
+
+def mean_waiting_time(pop_size, rates, *, replicates=1000, seed=0,
+                      max_generations=DEFAULT_MAX_GENERATIONS):
+    """ :return: Mean first-appearance time over independent seeded replicates. """
+    rng = random.Random(seed)
+    total = 0
+    for _ in range(replicates):
+        total += waiting_time(pop_size, rates, rng, max_generations=max_generations)
+    return total / replicates

--- a/kaxis/test_analytic.py
+++ b/kaxis/test_analytic.py
@@ -1,0 +1,38 @@
+""" Tests for the closed-form waiting-time referee.
+
+The one-step form is exact; the two-step form is the Durrett-Schmidt
+approximation whose signature is the square root on the second rate.
+"""
+
+import unittest
+
+from kaxis import analytic
+
+
+class TestOneStep(unittest.TestCase):
+
+    def test_matches_the_geometric_appearance_probability(self):
+        # One survivor, a coin-flip rate: appearance probability 1/2, so wait 2.
+        self.assertAlmostEqual(2.0, analytic.one_step_wait(1, 0.5))
+
+    def test_larger_population_waits_less(self):
+        self.assertLess(analytic.one_step_wait(1000, 1e-4),
+                        analytic.one_step_wait(10, 1e-4))
+
+
+class TestTwoStep(unittest.TestCase):
+
+    def test_scales_as_the_square_root_of_the_second_rate(self):
+        # Cutting u2 by 16 lengthens the wait by sqrt(16) = 4, not by 16.
+        base = analytic.two_step_wait(1000, 1e-3, 1.6e-4)
+        rarer = analytic.two_step_wait(1000, 1e-3, 1.6e-4 / 16)
+        self.assertAlmostEqual(4.0, rarer / base)
+
+    def test_scales_inversely_with_population_and_first_rate(self):
+        base = analytic.two_step_wait(1000, 1e-3, 1e-5)
+        self.assertAlmostEqual(base / 2.0, analytic.two_step_wait(2000, 1e-3, 1e-5))
+        self.assertAlmostEqual(base / 2.0, analytic.two_step_wait(1000, 2e-3, 1e-5))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kaxis/test_population.py
+++ b/kaxis/test_population.py
@@ -1,0 +1,55 @@
+""" Tests for the Wright-Fisher waiting-time engine.
+
+Two kinds of check: the sampler primitives behave, and the whole engine
+reproduces the analytic waiting times. The second kind is the point of the
+slice, so it is asserted against analytic.py, not against a frozen number.
+"""
+
+import random
+import unittest
+
+from kaxis import analytic, population
+
+
+class TestBinomial(unittest.TestCase):
+
+    def test_mean_is_trials_times_probability(self):
+        rng = random.Random(0)
+        draws = [population._binomial(1000, 0.01, rng) for _ in range(4000)]  # pylint: disable=protected-access
+        self.assertAlmostEqual(10.0, sum(draws) / len(draws), delta=0.5)
+
+    def test_degenerate_probabilities(self):
+        rng = random.Random(0)
+        self.assertEqual(0, population._binomial(1000, 0.0, rng))  # pylint: disable=protected-access
+        self.assertEqual(1000, population._binomial(1000, 1.0, rng))  # pylint: disable=protected-access
+        self.assertEqual(0, population._binomial(0, 0.5, rng))  # pylint: disable=protected-access
+
+
+class TestWaitingTime(unittest.TestCase):
+
+    def test_is_deterministic_for_a_seed(self):
+        first = population.mean_waiting_time(1000, (1e-4,), replicates=200, seed=3)
+        second = population.mean_waiting_time(1000, (1e-4,), replicates=200, seed=3)
+        self.assertEqual(first, second)
+
+    def test_one_step_matches_the_exact_analytic_wait(self):
+        pop_size, rate = 1000, 3.36e-5
+        simulated = population.mean_waiting_time(pop_size, (rate,), replicates=4000, seed=1)
+        predicted = analytic.one_step_wait(pop_size, rate)
+        self.assertLess(abs(simulated / predicted - 1.0), 0.05)
+
+    def test_two_step_wait_grows_as_the_square_root_not_linearly(self):
+        # The discriminating test: cutting u2 by 16 should lengthen the wait by
+        # about sqrt(16) = 4 (drift-assisted, Durrett-Schmidt), not by 16 (the
+        # naive "both mutations at once" model). A neutral intermediate drifts and
+        # gives the second step many extra chances.
+        pop_size, rate1 = 1000, 1e-3
+        rarer = population.mean_waiting_time(pop_size, (rate1, 8e-6), replicates=150, seed=7)
+        common = population.mean_waiting_time(pop_size, (rate1, 128e-6), replicates=150, seed=107)
+        ratio = rarer / common
+        self.assertGreater(ratio, 2.5)
+        self.assertLess(ratio, 7.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kaxis/validate.py
+++ b/kaxis/validate.py
@@ -1,0 +1,58 @@
+""" validate.py - show the engine reproduces the mainstream waiting time.
+
+This is slice 5, the credibility foundation of the K-axis apparatus. It prints,
+in a form a reader can check, that the Wright-Fisher engine in population.py
+matches the analytic waiting time for a K-step structure with neutral
+intermediates:
+
+  - K = 1: the exact geometric appearance time. A sharp unit check.
+  - K = 2: the Durrett-Schmidt drift-assisted law. The discriminating fact is
+    that cutting the second rate by 16 lengthens the wait by about sqrt(16) = 4,
+    not by 16. A neutral intermediate drifts to modest frequency and gives the
+    second step many extra chances, so the wait grows like 1/sqrt(u2). Reproducing
+    that, and not the naive 1/u2, is what shows the engine is faithful rather than
+    a toy.
+
+Once the engine is trusted, later slices vary K and the selection strength and
+read off buildability(K); the neutral, selection-off, large-K corner is the
+origin-of-replicator limit.
+"""
+
+import sys
+
+from kaxis import analytic, population
+
+POP_SIZE = 1000
+ONE_STEP_RATE = 3.36e-5
+FIRST_RATE = 1e-3
+RARE_SECOND = 8e-6
+COMMON_SECOND = 128e-6  # sixteen times RARE_SECOND
+
+
+def main():
+    """ Prints the one-step and two-step validation against the referee. """
+    simulated = population.mean_waiting_time(
+        POP_SIZE, (ONE_STEP_RATE,), replicates=4000, seed=1)
+    predicted = analytic.one_step_wait(POP_SIZE, ONE_STEP_RATE)
+    print('K = 1 (exact geometric appearance time):')
+    print(f'  simulated {simulated:.1f} generations vs analytic {predicted:.1f}'
+          f'  (ratio {simulated / predicted:.3f})')
+    print()
+
+    rarer = population.mean_waiting_time(
+        POP_SIZE, (FIRST_RATE, RARE_SECOND), replicates=150, seed=7)
+    common = population.mean_waiting_time(
+        POP_SIZE, (FIRST_RATE, COMMON_SECOND), replicates=150, seed=107)
+    print('K = 2 (neutral intermediate), second rate cut by 16x:')
+    print(f'  wait grows {rarer / common:.2f}x')
+    print('  drift-assisted (Durrett-Schmidt) predicts ~4x (sqrt of 16);'
+          ' the naive "both at once" model predicts 16x.')
+    print()
+    print('The engine reproduces the mainstream waiting time, including the'
+          ' nontrivial square-root law, so it is trusted to measure'
+          ' buildability(K).')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/protocell/PLAN.md
+++ b/protocell/PLAN.md
@@ -151,6 +151,17 @@ not a paper. We decide that on evidence, later.
     "no building in THIS substrate," not a universal claim. Whether adding those
     features changes it is the knob-dependence study (slice 5+), and the honest
     framing stays "buildability depends on evolvability," measured, not assumed.
+- **Slice 5** (pivot to the K-axis apparatus, see `kaxis/`): the build/degrade
+  question was generalized into one controlled experiment whose knob is the
+  coordination number K (how many things must be simultaneously right before any
+  reward), with selection strength as a second dial so that the origin-of-
+  replicator case is just the large-K, selection-off corner. Before measuring
+  buildability(K), slice 5 validates the evolutionary engine against mainstream
+  population genetics: a Wright-Fisher engine with neutral intermediates
+  reproduces the exact one-step geometric wait and the Durrett-Schmidt two-step
+  square-root law (wait grows like 1/sqrt(u2), not 1/u2). The engine is therefore
+  not dismissible as rigged, which is the foundation the buildability(K) sweep
+  (slice 6) will stand on.
 
 ## Revisable assumptions (expect slice feedback to change these)
 


### PR DESCRIPTION
## The pivot this implements

After the protocell build/degrade result (#52), a critical-direction discussion reframed the effort into **one controlled apparatus** whose knob is the **coordination number K**: how many specific things must be simultaneously right before *any* reward exists. Selection strength is a second dial, so the **origin-of-replicator** case is just the large-K, selection-off corner (where "no gradient" is a logical necessity, not a modeling choice). Tuning an existing function (K=1, gradient present, easy) and creating new coordinated structure (large K, no functional intermediate) become two settings of the same experiment.

The load-bearing honesty rule: **no authored intermediate rewards.** Injecting a gradient injects the conclusion. Neutral intermediates are the default hard case. Framing committed as a bias-guard in `kaxis/README.md`.

## What slice 5 does: earn the right to trust the engine

Before claiming anything about buildability(K), the engine has to reproduce the waiting time a population geneticist would compute, or a critic rightly dismisses it as rigged.

- `kaxis/population.py`: a minimal Wright-Fisher engine for a K-step structure with **neutral intermediates**, recording first appearance of the full K-step genome. Pure-stdlib `random` (matches the repo), geometric-gap binomial so every draw stays fast.
- `kaxis/analytic.py`: the referee. Exact geometric one-step wait; Durrett-Schmidt (2008, *Genetics* 180:1501) two-step law `1/(2 N u1 sqrt(u2))` for a neutral intermediate.

## Result

- **K = 1**: reproduces the exact geometric appearance time, ratio **0.997**.
- **K = 2**: reproduces the **drift-assisted square-root law**. Cutting the second rate by 16 lengthens the wait by **~4x = sqrt(16)**, not by 16. Log-log slope **-0.56**, not the naive **-1**. A neutral intermediate drifts to modest frequency and gives the second step many extra chances.
- The prefactor sits a stable ~3x above the D-S asymptotic constant (their formula is an as-u2->0 approximation with an order-1 constant), so we validate the **scaling law**, not the constant. Recorded in `kaxis/data/waiting_validation.txt`.

Run it: `python -m kaxis.validate` (about 7s).

## Verification

- pylint **10.00/10** on `kaxis/`
- **9 tests**, ~7s. The two-step test asserts the square-root scaling (ratio in [2.5, 7.0]), which discriminates drift-assisted from the naive linear model; stable across seeds.

## Next

Slice 6 sweeps K under honest whole-organism selection and reads off buildability(K); then real biology is placed on the K-axis (ridge/ DMS landscapes for the low-K tuning end, de novo function frequencies for the "how rare is function at all" end), then a prior-art lit-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)