### PR TITLE
K-axis slice 6: buildability(K), and what the gradient assumption is worth

### DIFF
--- a/kaxis/README.md
+++ b/kaxis/README.md
@@ -55,16 +55,47 @@ neutral intermediates, checked against the analytic waiting time (analytic.py):
   -1. See data/waiting_validation.txt.
 
 Because the engine matches the waiting time a population geneticist would compute,
-it cannot be dismissed as rigged. That is the foundation the later buildability(K)
-slices stand on. Run it: `python -m kaxis.validate`.
+it cannot be dismissed as rigged. That is the foundation the buildability(K)
+slice stands on. Run it: `python -m kaxis.validate`.
+
+## Slice 6: buildability(K), and what the gradient assumption is worth
+
+With the engine trusted, slice 6 asks the real question. Building a K-part
+structure is run in two regimes on the same engine and the same mutation supply:
+no gradient (every intermediate neutral, nothing rewards a half-built structure)
+and gradient (each completed step is itself beneficial). The selection dial is
+first validated on its own: a beneficial mutant fixes at about Haldane's 2s
+(`population.fixation_fraction` vs Kimura's formula in analytic.py).
+
+Result (mean generations to build, N=1000, step rate 5e-4, selection 0.1):
+
+| K | no gradient | gradient | cost ratio |
+|---|-------------|----------|------------|
+| 1 | 2.5         | 2.5      | 1.0x       |
+| 2 | 101.8       | 39.4     | 2.6x       |
+| 3 | 646.0       | 79.9     | 8.1x       |
+| 4 | 2015.0      | 125.9    | 16.0x      |
+| 5 | 3509.0      | 179.5    | 19.5x      |
+| 6 | 4900.1      | 222.6    | 22.0x      |
+
+With a gradient the cost grows about **linearly** in K; without one it grows far
+faster, so the **cost ratio widens with every added part**. That widening is the
+measured worth, in generations, of the gradient assumption. In a mutation-limited
+regime (Nu << 1) the no-gradient case does not merely slow down, it stops
+finishing within a fixed resource budget while the gradient still always builds
+(see data/buildability_curve.txt). Run it: `python -m kaxis.buildability`.
+
+This does not decide where real biology sits on the K-axis (how often a partial
+structure is actually rewarded). It makes that the measurable question, which is
+the honest and un-dismissable form of the argument.
 
 ## Next slices
 
-- **Slice 6**: sweep K under honest whole-organism selection and read off
-  buildability(K), with selection strength as the second dial (origin-of-
-  replicator = the large-K, selection-off corner).
-- **Then**: place real biology on the K-axis using measured data (the ridge/ DMS
-  landscapes for the low-K tuning end; de novo function frequencies such as
-  Keefe and Szostak's 37-bit ATP binders for the "how rare is function at all"
-  end), and lit-check (Avida, Tierra, and the waiting-time literature) before any
+- **Place real biology on the K-axis** using measured data: the ridge/ DMS
+  landscapes for the low-K tuning end, de novo function frequencies such as Keefe
+  and Szostak's 37-bit ATP binders for the "how rare is function at all" end.
+- **A protocell demonstration** of the same K contrast in readable code, so a
+  layperson can see the structure that did or did not get built, not only the
+  curve.
+- **Lit-check** (Avida, Tierra, and the waiting-time literature) before any
   write-up.

--- a/kaxis/analytic.py
+++ b/kaxis/analytic.py
@@ -30,3 +30,15 @@ def two_step_wait(pop_size, rate1, rate2):
     Approximation; assumes rate2 << 1 / pop_size (the drift-assisted regime).
     """
     return 1.0 / (2.0 * pop_size * rate1 * math.sqrt(rate2))
+
+
+def fixation_probability(pop_size, sel):
+    """ :return: Kimura's fixation probability of one new (1+sel) mutant.
+
+    (1 - e^-2s) / (1 - e^-2Ns) for a single copy at frequency 1/N. About 2*sel
+    when sel is small and N*sel is large (Haldane). This is the referee for the
+    selection dial.
+    """
+    if sel == 0.0:
+        return 1.0 / pop_size
+    return (1.0 - math.exp(-2.0 * sel)) / (1.0 - math.exp(-2.0 * pop_size * sel))

--- a/kaxis/buildability.py
+++ b/kaxis/buildability.py
@@ -1,0 +1,103 @@
+""" buildability.py - how the cost of building a K-part structure depends on K.
+
+Slice 6. With the engine validated (waiting time and fixation both match the
+math, see analytic.py), we can now ask the question the whole apparatus is for:
+how hard is it to build a structure that needs K coordinated parts, and how much
+of the answer is carried by the assumption that a gradient of useful
+intermediates exists?
+
+Two regimes, same engine, same mutation supply:
+
+  - NO GRADIENT: every intermediate is neutral. Nothing rewards a half-built
+    structure, so selection is blind to progress; only mutation and drift cross
+    the gap. This is the honest hard case, and the one that applies when a part
+    is useless until the whole assembly is present.
+  - GRADIENT: each completed step is itself beneficial (selection coefficient
+    `selection`), so a partial structure is favored and selection carries it up
+    step by step. This is the assumption most digital-evolution successes rely on.
+
+The readout is buildability(K): the mean generations to first build the full
+structure, and the fraction of runs that build it within a fixed resource budget.
+The contrast between the two regimes is the point: it measures, in generations,
+what the gradient assumption is worth.
+
+No intermediate reward is ever hand-authored in the no-gradient regime; that is
+the bias guard. When we study the gradient, it is an explicit, reported variable.
+"""
+
+import random
+import statistics
+import sys
+
+from kaxis import population
+
+POP_SIZE = 1000
+STEP_RATE = 5e-4
+SELECTION = 0.1
+BUDGET = 300000
+REPLICATES = 60
+COORDINATION_NUMBERS = (1, 2, 3, 4, 5, 6)
+
+
+def _neutral_fitness(coordination):
+    """ :return: All-neutral fitness for a K-step genome (no gradient). """
+    return [1.0] * (coordination + 1)
+
+
+def _gradient_fitness(coordination, selection):
+    """ :return: Fitness rising by (1+selection) per completed step (a gradient). """
+    return [(1.0 + selection) ** step for step in range(coordination + 1)]
+
+
+def build_stats(coordination, *, gradient, pop_size=POP_SIZE, rate=STEP_RATE,
+                selection=SELECTION, budget=BUDGET, replicates=REPLICATES, seed=0):
+    # The knobs are all reported experiment parameters, so they are explicit
+    # arguments rather than hidden state.
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """ :return: (fraction built within budget, mean generations among those built). """
+    rates = (rate,) * coordination
+    fitness = (_gradient_fitness(coordination, selection) if gradient
+               else _neutral_fitness(coordination))
+    rng = random.Random(seed)
+    times = [population.waiting_time(pop_size, rates, rng, fitness=fitness,
+                                     max_generations=budget)
+             for _ in range(replicates)]
+    built = [time for time in times if time < budget]
+    fraction = len(built) / replicates
+    mean_time = statistics.mean(built) if built else float('inf')
+    return fraction, mean_time
+
+
+def curve(*, gradient, coordination_numbers=COORDINATION_NUMBERS, **knobs):
+    """ :return: {K: (fraction built, mean time)} across the coordination numbers. """
+    return {coordination: build_stats(coordination, gradient=gradient,
+                                      seed=100 + coordination, **knobs)
+            for coordination in coordination_numbers}
+
+
+def main():
+    """ Prints buildability(K) for the no-gradient and gradient regimes. """
+    no_gradient = curve(gradient=False)
+    gradient = curve(gradient=True)
+    print(f'Buildability(K): pop={POP_SIZE}, step rate={STEP_RATE}, '
+          f'selection={SELECTION}, {REPLICATES} runs each.')
+    print('Mean generations to build a K-part structure:')
+    print(f"  {'K':>2}  {'no gradient':>12}  {'gradient':>10}  "
+          f"{'cost ratio':>10}")
+    for coordination in COORDINATION_NUMBERS:
+        neutral_time = no_gradient[coordination][1]
+        gradient_time = gradient[coordination][1]
+        ratio = neutral_time / gradient_time if gradient_time else float('inf')
+        print(f"  {coordination:>2}  {neutral_time:>12.1f}  {gradient_time:>10.1f}  "
+              f"{ratio:>9.1f}x")
+    print()
+    print('With a gradient the cost grows about linearly with K. Without one it')
+    print('grows far faster, so the cost ratio widens with every added part: the')
+    print('gradient assumption is doing the work. Where real biology sits on this')
+    print('axis (how often a partial structure is actually rewarded) is the')
+    print('empirical question this makes measurable, not one we settle here.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/kaxis/data/buildability_curve.txt
+++ b/kaxis/data/buildability_curve.txt
@@ -1,0 +1,58 @@
+K-axis slice 6: buildability(K), gradient vs no gradient.
+
+How hard is it to build a structure that needs K coordinated parts, and how much
+of the answer is carried by assuming a gradient of useful intermediates exists?
+Same engine (validated in slice 5 for waiting time and here for the selection
+dial), same mutation supply, two regimes:
+
+  - NO GRADIENT: every intermediate is neutral (nothing rewards a half-built
+    structure). No intermediate reward is ever hand-authored; this is the bias
+    guard.
+  - GRADIENT: each completed step is itself beneficial (selection = 0.1), so a
+    partial structure is favored and carried up step by step.
+
+Selection dial validated (population.fixation_fraction vs Kimura, N=1000):
+  s=0.02: simulated 0.0413   Kimura 0.0392
+  s=0.05: simulated 0.0893   Kimura 0.0952
+  s=0.10: simulated 0.1783   Kimura 0.1813
+A beneficial mutant fixes at about Haldane's 2s, so the selection dial is faithful.
+
+--- Time curve (the robust, budget-independent result) ---
+N=1000, step rate=5e-4, selection=0.1, 60 runs each. Mean generations to build:
+   K   no gradient     gradient   cost ratio
+   1           2.5          2.5        1.0x
+   2         101.8         39.4        2.6x
+   3         646.0         79.9        8.1x
+   4        2015.0        125.9       16.0x
+   5        3509.0        179.5       19.5x
+   6        4900.1        222.6       22.0x
+
+With a gradient the cost grows about LINEARLY with K. Without one it grows far
+faster, so the cost RATIO widens with every added part. That widening ratio is
+the measured worth, in generations, of the gradient assumption.
+
+--- Probability collapse (mutation-limited regime) ---
+When mutation supply is low (Nu << 1), each neutral step is an independent rare
+crossing and the no-gradient case does not just get slower, it stops finishing
+within a fixed resource budget. N=150, step rate=6e-5 (Nu=0.009), selection=0.1,
+budget=120000 generations, 60 runs each:
+   K   no-gradient built   no-grad mean time   gradient built   grad time
+   2               1.00              9186.5             1.00       795.5
+   3               1.00             22770.3             1.00      1468.2
+   4               1.00             42393.4             1.00      2301.0
+   5               0.93             62655.0             1.00      2902.1
+   6               0.82             66459.4             1.00      3445.9
+The gradient always builds (cost linear); the no-gradient case starts failing to
+build within the budget as K rises. The build-probability numbers depend on the
+chosen budget, but the direction (gradient builds, no-gradient increasingly does
+not) does not.
+
+Reading: buildability(K) is mild with a gradient and steep without one. The
+apparatus does not decide where real biology sits on the K-axis (how often a
+partial structure is actually rewarded); it makes that the measurable question.
+
+Reproduce:
+  from kaxis import buildability
+  print(buildability.build_stats(6, gradient=False, pop_size=150, rate=6e-5,
+        budget=120000, replicates=60, seed=106))   # (0.82, 66459.4)
+  # time curve: python -m kaxis.buildability

--- a/kaxis/data/waiting_validation.txt
+++ b/kaxis/data/waiting_validation.txt
@@ -6,17 +6,19 @@ kaxis/validate.py; this file is the fuller record, including the log-log slope.
 
 Model: population.py. A constant population must complete K sequential steps;
 every intermediate is selectively NEUTRAL; only the finished K-step genome is
-recorded, at first appearance. Referee: analytic.py.
+recorded, at first appearance. Referee: analytic.py. (As of slice 6 the drift
+resample uses a normal approximation once a class is common, standard and
+statistically equivalent; the numbers below are from that current engine.)
 
 One step (exact geometric appearance time), N=1000, u1=3.36e-5, 4000 replicates:
   simulated = 30.188   analytic = 30.264   ratio = 0.9975
   The engine's mutation supply and timing are exact.
 
 Two steps (neutral intermediate), N=1000, u1=1e-3, 400 replicates per point:
-  u2 = 1.0e-06:  simulated = 1680.2   analytic (D-S) = 500.0   ratio = 3.36
-  u2 = 4.0e-06:  simulated =  834.7   analytic (D-S) = 250.0   ratio = 3.34
-  u2 = 1.6e-05:  simulated =  355.7   analytic (D-S) = 125.0   ratio = 2.85
-  slope of log(mean wait) vs log(u2) = -0.560
+  u2 = 1.0e-06:  simulated = 1738.7   analytic (D-S) = 500.0   ratio = 3.48
+  u2 = 4.0e-06:  simulated =  756.7   analytic (D-S) = 250.0   ratio = 3.03
+  u2 = 1.6e-05:  simulated =  356.5   analytic (D-S) = 125.0   ratio = 2.85
+  slope of log(mean wait) vs log(u2) = -0.571
 
 Reading:
   - The slope is -0.56, i.e. the wait grows like u2^(-1/2), the Durrett-Schmidt

--- a/kaxis/population.py
+++ b/kaxis/population.py
@@ -2,55 +2,73 @@
 
 The credibility foundation for the whole K-axis apparatus. Before we ever claim
 something about how hard it is to build a coordinated K-part structure, we have
-to show our evolutionary engine reproduces the waiting time that mainstream
-population genetics predicts for the same model. If it does, no one can call the
-engine rigged; if it does not, the engine is wrong and we fix it before going on.
+to show our evolutionary engine reproduces the results that mainstream population
+genetics predicts for the same model. If it does, no one can call the engine
+rigged; if it does not, the engine is wrong and we fix it before going on.
 
 The model is deliberately bare:
 
   - A constant population of `pop_size` asexual replicators.
   - A genome that must complete K sequential steps. `rates[i]` is the
     per-individual per-generation probability of advancing from step i to i+1.
-  - Every intermediate (0..K-1 steps done) is selectively NEUTRAL. Only the
-    finished K-step genome is "the structure"; we time its first appearance.
+  - A `fitness` per class sets the selection regime. With every intermediate
+    NEUTRAL (the default), nothing rewards a half-built structure, so selection
+    is blind to progress and only mutation supply and neutral drift can cross the
+    gap. That is the honest, hard case, and the regime Durrett and Schmidt (2008)
+    solved. With intermediates increasingly fit, there is a GRADIENT and each
+    step is selected up as it appears.
   - No back mutation, no recombination.
 
-Neutral intermediates are the honest, hard case: nothing rewards a half-built
-structure, so selection is blind to the intermediates and the only forces are
-mutation supply and neutral drift. That is exactly the regime Durrett and Schmidt
-(2008) solved analytically, which is our referee in analytic.py.
+Two things are validated against closed forms in analytic.py: the neutral
+waiting time (mutation and drift) and the fixation probability of a beneficial
+mutant (selection). Once both dials match the math, the engine is trusted.
 
 Sampling is pure-stdlib `random` for determinism, matching the rest of the repo.
-Both the mutation step and the drift resample act only on rare classes (the
-intermediates are always a small minority in this regime), so a geometric-gap
-binomial sampler keeps every draw fast.
+The binomial sampler steps between successes when a tail is rare (mutation, rare
+intermediates) and switches to a normal approximation when both tails are large
+(a beneficial class sweeping to high frequency), so every generation stays fast.
 """
 
 import math
 import random
 
 DEFAULT_MAX_GENERATIONS = 10 ** 8
+_NORMAL_THRESHOLD = 30.0
+
+
+def _geometric_binomial(trials, prob, rng):
+    """ :return: A Binomial(trials, prob) draw by stepping between successes.
+
+    Fast only when the expected count is small; callers route the rarer tail here.
+    """
+    log_q = math.log1p(-prob)
+    count = 0
+    index = -1
+    while True:
+        index += int(math.log(1.0 - rng.random()) / log_q) + 1
+        if index >= trials:
+            return count
+        count += 1
 
 
 def _binomial(trials, prob, rng):
-    """ :return: An exact Binomial(trials, prob) draw via geometric gap skipping.
+    """ :return: A Binomial(trials, prob) draw, exact for rare tails.
 
-    Fast when prob is small (the regime here), because it steps from one success
-    to the next rather than testing every trial.
+    Uses a normal approximation only when both expected counts exceed the
+    threshold (a diffusion-scale draw, standard in population genetics); otherwise
+    it steps between successes on whichever tail is rarer, which stays exact.
     """
     if trials <= 0 or prob <= 0.0:
         return 0
     if prob >= 1.0:
         return trials
-    log_q = math.log1p(-prob)
-    count = 0
-    index = -1
-    while True:
-        gap = int(math.log(1.0 - rng.random()) / log_q)
-        index += gap + 1
-        if index >= trials:
-            return count
-        count += 1
+    mean = trials * prob
+    if mean > _NORMAL_THRESHOLD and trials - mean > _NORMAL_THRESHOLD:
+        drawn = int(round(rng.gauss(mean, math.sqrt(mean * (1.0 - prob)))))
+        return min(trials, max(0, drawn))
+    if prob > 0.5:
+        return trials - _geometric_binomial(trials, 1.0 - prob, rng)
+    return _geometric_binomial(trials, prob, rng)
 
 
 def _advance(counts, rates, rng):
@@ -67,36 +85,40 @@ def _advance(counts, rates, rng):
     return new
 
 
-def _drift(counts, pop_size, rng):
-    """ :return: New class counts after one neutral Wright-Fisher resample.
+def _reproduce(counts, fitness, pop_size, rng):
+    """ :return: New class counts after one Wright-Fisher generation with selection.
 
-    Drawn as conditional binomials over the rare intermediate classes; the
-    ground state (step 0) takes the remainder, so every binomial draw has a small
-    probability and stays fast.
+    Reproduction is proportional to count times fitness. Drawn as conditional
+    binomials from the top class down, with the ground state taking the remainder.
+    With uniform fitness this reduces exactly to neutral drift.
     """
+    weights = [counts[step] * fitness[step] for step in range(len(counts))]
     new = [0] * len(counts)
     remaining = pop_size
-    prob_remaining = 1.0
+    weight_remaining = sum(weights)
     for step in range(len(counts) - 1, 0, -1):
-        if counts[step] == 0:
+        if weights[step] == 0.0:
             continue
-        prob = counts[step] / pop_size
-        drawn = _binomial(remaining, prob / prob_remaining, rng)
+        drawn = _binomial(remaining, weights[step] / weight_remaining, rng)
         new[step] = drawn
         remaining -= drawn
-        prob_remaining -= prob
+        weight_remaining -= weights[step]
     new[0] = remaining
     return new
 
 
-def waiting_time(pop_size, rates, rng, *, max_generations=DEFAULT_MAX_GENERATIONS):
+def waiting_time(pop_size, rates, rng, *, fitness=None,
+                 max_generations=DEFAULT_MAX_GENERATIONS):
     """ :return: Generations until the first genome completes all K steps.
 
-    K is len(rates). Appearance is recorded right after the mutation step, before
-    drift can lose it, matching "time until some individual has experienced all
-    the mutations."
+    K is len(rates). `fitness` is a per-class list of length K+1 (default all
+    neutral). Appearance is recorded right after the mutation step, before
+    reproduction can lose it. If the budget is exhausted first, returns the budget
+    (the structure was not built in time).
     """
     completed = len(rates)
+    if fitness is None:
+        fitness = [1.0] * (completed + 1)
     counts = [pop_size] + [0] * completed
     generation = 0
     while generation < max_generations:
@@ -104,15 +126,37 @@ def waiting_time(pop_size, rates, rng, *, max_generations=DEFAULT_MAX_GENERATION
         counts = _advance(counts, rates, rng)
         if counts[completed] >= 1:
             return generation
-        counts = _drift(counts, pop_size, rng)
+        counts = _reproduce(counts, fitness, pop_size, rng)
     return generation
 
 
-def mean_waiting_time(pop_size, rates, *, replicates=1000, seed=0,
+def mean_waiting_time(pop_size, rates, *, fitness=None, replicates=1000, seed=0,
                       max_generations=DEFAULT_MAX_GENERATIONS):
+    # All keyword-only knobs are reported experiment parameters, not hidden state.
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     """ :return: Mean first-appearance time over independent seeded replicates. """
     rng = random.Random(seed)
     total = 0
     for _ in range(replicates):
-        total += waiting_time(pop_size, rates, rng, max_generations=max_generations)
+        total += waiting_time(pop_size, rates, rng, fitness=fitness,
+                              max_generations=max_generations)
     return total / replicates
+
+
+def fixation_fraction(pop_size, sel, *, replicates=2000, seed=0):
+    """ :return: Fraction of runs in which one new (1+sel) mutant fixes.
+
+    Validates the selection dial: one beneficial copy among pop_size neutral ones,
+    reproduced under selection with no mutation, run to loss or fixation. The
+    fraction that fix is the referee quantity (Haldane/Kimura, about 2*sel).
+    """
+    rng = random.Random(seed)
+    fitness = (1.0, 1.0 + sel)
+    fixed = 0
+    for _ in range(replicates):
+        counts = [pop_size - 1, 1]
+        while 0 < counts[1] < pop_size:
+            counts = _reproduce(counts, fitness, pop_size, rng)
+        if counts[1] == pop_size:
+            fixed += 1
+    return fixed / replicates

--- a/kaxis/test_analytic.py
+++ b/kaxis/test_analytic.py
@@ -34,5 +34,15 @@ class TestTwoStep(unittest.TestCase):
         self.assertAlmostEqual(base / 2.0, analytic.two_step_wait(1000, 2e-3, 1e-5))
 
 
+class TestFixationProbability(unittest.TestCase):
+
+    def test_neutral_mutant_fixes_at_one_over_population(self):
+        self.assertAlmostEqual(1.0 / 1000, analytic.fixation_probability(1000, 0.0))
+
+    def test_small_advantage_approaches_haldane_two_s(self):
+        # Large population, tiny s: fixation probability is about 2s.
+        self.assertAlmostEqual(0.002, analytic.fixation_probability(100000, 0.001), places=5)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/kaxis/test_buildability.py
+++ b/kaxis/test_buildability.py
@@ -1,0 +1,48 @@
+""" Tests for the buildability(K) experiment.
+
+The claims are structural and hold on a fast parameter regime: a gradient makes
+a K-part structure much cheaper to build, and the cost of removing the gradient
+grows as K grows. Deterministic under seeding.
+"""
+
+import unittest
+
+from kaxis import buildability
+
+FAST = {'pop_size': 500, 'rate': 5e-4, 'budget': 8000, 'replicates': 60}
+
+
+def _time(coordination, *, gradient):
+    return buildability.build_stats(coordination, gradient=gradient,
+                                    seed=100 + coordination, **FAST)[1]
+
+
+class TestBuildability(unittest.TestCase):
+
+    def test_a_gradient_builds_a_three_part_structure_faster(self):
+        no_gradient = _time(3, gradient=False)
+        gradient = _time(3, gradient=True)
+        self.assertGreater(no_gradient, 2.0 * gradient)
+
+    def test_cost_of_removing_the_gradient_grows_with_k(self):
+        ratio_two = _time(2, gradient=False) / _time(2, gradient=True)
+        ratio_three = _time(3, gradient=False) / _time(3, gradient=True)
+        self.assertGreater(ratio_three, ratio_two)
+
+    def test_is_deterministic_for_a_seed(self):
+        first = buildability.build_stats(3, gradient=False, seed=7, **FAST)
+        second = buildability.build_stats(3, gradient=False, seed=7, **FAST)
+        self.assertEqual(first, second)
+
+    def test_both_regimes_build_within_budget_in_the_fast_regime(self):
+        self.assertEqual(1.0, _fraction(3, gradient=False))
+        self.assertEqual(1.0, _fraction(3, gradient=True))
+
+
+def _fraction(coordination, *, gradient):
+    return buildability.build_stats(coordination, gradient=gradient,
+                                    seed=100 + coordination, **FAST)[0]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kaxis/test_population.py
+++ b/kaxis/test_population.py
@@ -51,5 +51,15 @@ class TestWaitingTime(unittest.TestCase):
         self.assertLess(ratio, 7.0)
 
 
+class TestSelection(unittest.TestCase):
+
+    def test_fixation_fraction_matches_kimura(self):
+        # The selection dial: a beneficial mutant fixes at about Kimura's rate.
+        selection = 0.05
+        simulated = population.fixation_fraction(1000, selection, replicates=1500, seed=0)
+        predicted = analytic.fixation_probability(1000, selection)
+        self.assertLess(abs(simulated - predicted), 0.02)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## The question this answers

Slice 5 earned the right to trust the engine (it reproduces the mainstream waiting time). Slice 6 uses it to ask the real thing: **how does the cost of building a K-part coordinated structure grow with K, and how much of the answer is carried by assuming a gradient of useful intermediates exists?** This is the tuning-vs-creation distinction made quantitative.

## Engine change: the selection dial (validated separately)

- `waiting_time` now takes a per-class `fitness` vector. `_reproduce` is a fitness-weighted Wright-Fisher resample that **reduces exactly to neutral drift** when fitness is uniform, so all slice-5 validation is preserved. `_binomial` gains a normal-approximation branch so a class sweeping to high frequency stays fast.
- The dial is validated on its own, the same way slice 5 validated mutation and drift: a beneficial mutant fixes at about **Haldane's 2s** (`population.fixation_fraction` vs Kimura's `analytic.fixation_probability`; sim 0.089 vs 0.095 at s=0.05).

## Result

Same engine, same mutation supply, two regimes. **No gradient**: every intermediate is neutral, nothing rewards a half-built structure, and no intermediate reward is ever hand-authored (the bias guard). **Gradient**: each completed step is itself beneficial.

Mean generations to build (N=1000, step rate 5e-4, selection 0.1, 60 runs each):

| K | no gradient | gradient | cost ratio |
|---|-------------|----------|------------|
| 1 | 2.5         | 2.5      | 1.0x       |
| 2 | 101.8       | 39.4     | 2.6x       |
| 3 | 646.0       | 79.9     | 8.1x       |
| 4 | 2015.0      | 125.9    | 16.0x      |
| 5 | 3509.0      | 179.5    | 19.5x      |
| 6 | 4900.1      | 222.6    | 22.0x      |

- With a gradient the cost grows about **linearly** in K. Without one it grows far faster, so the **cost ratio widens with every added part** (1x to 22x). That widening is the measured worth, in generations, of the gradient assumption.
- In a **mutation-limited** regime (Nu << 1, N=150, rate 6e-5) the no-gradient case does not just slow down, it stops finishing within a fixed resource budget (build probability 0.93 at K=5, 0.82 at K=6) while the gradient still always builds. See `kaxis/data/buildability_curve.txt`.

## Why this is the honest form of the argument

It does **not** decide where real biology sits on the K-axis, i.e. how often a partial structure is actually rewarded. It makes that the measurable question and quantifies what the answer costs either way. Neither the field's optimistic assumption nor the skeptic's pessimistic one is baked in.

Run it: `python -m kaxis.buildability` (~8s).

## Verification

- pylint **10.00/10** on `kaxis/`
- **16 tests** (~3.4s). Buildability tests assert the structural claims (a gradient builds a 3-part structure faster; the cost ratio grows with K) on a fast seeded regime. Slice-5 waiting-time validation still passes on the updated engine; slope record refreshed to the current engine (-0.571).

## Next

Place real biology on the K-axis with measured data (ridge/ DMS landscapes for the low-K tuning end; Keefe and Szostak 37-bit ATP binders for the "how rare is function at all" end), then a readable protocell demonstration of the same K contrast, then a prior-art lit-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)